### PR TITLE
Implement updated design system from handoff

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Because of the way the original project data/model pipeline works, the tool does
 - Vue 3
 - TypeScript
 - ESLint
-- custom CSS
+- custom CSS design system (DM Sans + Lora, glassmorphic UI)
 - Chart.js via `vue-chartjs` wrapper
 
 ## App Structure

--- a/app/assets/styles/prediction.css
+++ b/app/assets/styles/prediction.css
@@ -427,6 +427,7 @@ a {
 	cursor: pointer;
 }
 
+/* Chevron stroke colors mirror --text-muted (light #74685b, dark #9e998f); data URIs cannot use CSS variables. */
 .prediction-field-select {
 	background-image: url("data:image/svg+xml,%3Csvg width='12' height='8' viewBox='0 0 12 8' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M1 1.5L6 6.5L11 1.5' stroke='%2374685b' stroke-width='1.5' stroke-linecap='round' stroke-linejoin='round'/%3E%3C/svg%3E");
 	background-repeat: no-repeat;

--- a/app/assets/styles/prediction.css
+++ b/app/assets/styles/prediction.css
@@ -1,19 +1,70 @@
+/* Prediction Tool — design system (from design handoff) */
+
 :root {
 	color-scheme: light;
-	--font-body: 'Avenir Next', 'SF Pro Text', 'Helvetica Neue', 'Segoe UI', Arial, sans-serif;
-	--font-body-cjk:
-		'PingFang SC',
-		'Hiragino Sans GB',
-		'Noto Sans CJK SC',
-		'Noto Sans SC',
-		'Microsoft YaHei',
-		'Source Han Sans SC',
-		'Heiti SC',
+	--font-body: 'DM Sans', 'Avenir Next', 'SF Pro Text', 'Helvetica Neue', 'Segoe UI', Arial,
 		sans-serif;
-	--font-display: 'Iowan Old Style', 'Palatino Linotype', 'Book Antiqua', Georgia, serif;
+	--font-display: 'Lora', 'Iowan Old Style', 'Palatino Linotype', 'Book Antiqua', Georgia, serif;
+	--font-body-cjk:
+		'PingFang SC', 'Hiragino Sans GB', 'Noto Sans CJK SC', 'Noto Sans SC', 'Microsoft YaHei',
+		'Source Han Sans SC', 'Heiti SC', sans-serif;
+
+	--text: #1f2328;
+	--text-muted: #74685b;
+	--primary: #234b61;
+	--accent: #af6542;
+	--page-bg: #f5eee5;
+	--panel-bg: rgba(255, 250, 244, 0.72);
+	--panel-strong: rgba(255, 253, 250, 0.82);
+	--results-bg: rgba(255, 252, 248, 0.9);
+	--results-bg-2: rgba(249, 243, 236, 0.84);
+	--price-panel-bg: rgba(255, 255, 255, 0.46);
+	--field-bg: rgba(255, 255, 255, 0.54);
+	--pill-bg: rgba(255, 251, 246, 0.56);
+	--line-soft: rgba(116, 92, 68, 0.14);
+	--focus-ring: rgba(35, 75, 97, 0.12);
+	--shadow: rgba(110, 84, 63, 0.12);
+	--accent-shadow: rgba(175, 101, 66, 0.24);
+	--mesh-line: rgba(31, 35, 40, 0.04);
+	--orb-color: rgba(175, 101, 66, 0.14);
+	--chart-grid: rgba(31, 35, 40, 0.08);
+	--chart-line: #af6542;
+	--chart-fill: rgba(175, 101, 66, 0.12);
+	--gradient-page: linear-gradient(155deg, #f5eee5 0%, #eee4d8 50%, #ece6de 100%);
+	--gradient-results: linear-gradient(180deg, var(--results-bg) 0%, var(--results-bg-2) 100%);
+	--btn-text: #fffaf3;
 }
 
-* {
+[data-theme='dark'] {
+	color-scheme: dark;
+
+	--text: #f2ede6;
+	--text-muted: #9e998f;
+	--primary: #8daec1;
+	--accent: #cf8b60;
+	--page-bg: #091017;
+	--panel-bg: rgba(16, 23, 31, 0.78);
+	--panel-strong: rgba(18, 27, 37, 0.88);
+	--results-bg: rgba(18, 26, 35, 0.92);
+	--results-bg-2: rgba(15, 22, 30, 0.86);
+	--price-panel-bg: rgba(255, 255, 255, 0.04);
+	--field-bg: rgba(255, 255, 255, 0.04);
+	--pill-bg: rgba(255, 255, 255, 0.04);
+	--line-soft: rgba(141, 174, 193, 0.16);
+	--focus-ring: rgba(141, 174, 193, 0.14);
+	--shadow: rgba(0, 0, 0, 0.32);
+	--accent-shadow: rgba(207, 139, 96, 0.26);
+	--mesh-line: rgba(255, 255, 255, 0.06);
+	--orb-color: rgba(207, 139, 96, 0.18);
+	--chart-grid: rgba(255, 255, 255, 0.08);
+	--chart-line: #cf8b60;
+	--chart-fill: rgba(207, 139, 96, 0.16);
+	--gradient-page: linear-gradient(155deg, #091017 0%, #101821 52%, #1a2430 100%);
+}
+
+*,
+*::before,
+*::after {
 	box-sizing: border-box;
 }
 
@@ -26,16 +77,14 @@ body,
 }
 
 body {
-	background: var(--page-bg, #f6efe6);
-	color: var(--text-color, #1f2328);
+	background: var(--page-bg);
+	color: var(--text);
 	font-family: var(--font-body);
+	-webkit-font-smoothing: antialiased;
+	-moz-osx-font-smoothing: grayscale;
 	transition:
-		background 0.35s ease,
-		color 0.25s ease;
-}
-
-body[data-theme='dark'] {
-	color-scheme: dark;
+		background 0.45s ease,
+		color 0.3s ease;
 }
 
 html[data-lang='zh'] {
@@ -51,35 +100,39 @@ a {
 	text-decoration: none;
 }
 
+/* Shell */
 .prediction-shell {
 	position: relative;
 	isolation: isolate;
 	overflow: hidden;
 	min-height: 100vh;
 	padding: 26px 28px 42px;
-	color: var(--text-color);
-}
-
-.prediction-shell::before,
-.prediction-shell::after {
-	content: '';
-	position: fixed;
-	pointer-events: none;
-	z-index: 0;
-	opacity: 0.75;
+	background: var(--gradient-page);
+	color: var(--text);
+	transition:
+		background 0.45s ease,
+		color 0.3s ease;
 }
 
 .prediction-shell::before {
+	content: '';
+	position: fixed;
 	inset: 0;
+	pointer-events: none;
+	z-index: 0;
 	background-image:
-		linear-gradient(var(--mesh-line, rgba(31, 35, 40, 0.04)) 1px, transparent 1px),
-		linear-gradient(90deg, var(--mesh-line, rgba(31, 35, 40, 0.04)) 1px, transparent 1px);
+		linear-gradient(var(--mesh-line) 1px, transparent 1px),
+		linear-gradient(90deg, var(--mesh-line) 1px, transparent 1px);
 	background-size: 42px 42px;
 	mask-image: radial-gradient(circle at center, black 40%, transparent 88%);
+	-webkit-mask-image: radial-gradient(circle at center, black 40%, transparent 88%);
 	opacity: 0.22;
+	transition: background-image 0.45s ease;
 }
 
 .prediction-shell::after {
+	content: '';
+	position: fixed;
 	width: 46vw;
 	height: 46vw;
 	max-width: 560px;
@@ -87,8 +140,12 @@ a {
 	top: -180px;
 	right: -140px;
 	border-radius: 50%;
-	background: radial-gradient(circle, var(--orb-color, rgba(191, 115, 72, 0.16)) 0%, transparent 68%);
+	background: radial-gradient(circle, var(--orb-color) 0%, transparent 68%);
 	filter: blur(12px);
+	opacity: 0.78;
+	pointer-events: none;
+	z-index: 0;
+	transition: background 0.45s ease;
 }
 
 .prediction-surface {
@@ -98,6 +155,7 @@ a {
 	margin: 0 auto;
 }
 
+/* Topbar */
 .prediction-topbar {
 	display: flex;
 	justify-content: space-between;
@@ -110,16 +168,20 @@ a {
 	display: inline-flex;
 	align-items: center;
 	padding: 8px 14px;
-	margin: 0;
-	border: 1px solid var(--line-soft, rgba(116, 92, 68, 0.14));
+	border: 1px solid var(--line-soft);
 	border-radius: 999px;
-	background: var(--pill-bg, rgba(255, 251, 246, 0.56));
-	color: var(--accent-color, #af6542);
+	background: var(--pill-bg);
+	color: var(--accent);
 	font-size: 11px;
 	font-weight: 800;
 	text-transform: uppercase;
 	letter-spacing: 1.4px;
 	backdrop-filter: blur(12px);
+	-webkit-backdrop-filter: blur(12px);
+	transition:
+		background 0.3s ease,
+		color 0.3s ease,
+		border-color 0.3s ease;
 }
 
 .prediction-actions {
@@ -128,57 +190,39 @@ a {
 	align-items: center;
 }
 
-.prediction-language-toggle {
-	display: inline-flex;
-}
-
-.prediction-ghost-button.el-button,
-.prediction-primary-button.el-button,
-.prediction-reset-button.el-button,
-.prediction-language-toggle .el-button {
+.prediction-ghost-btn {
 	min-height: 42px;
 	padding: 10px 16px;
 	border-radius: 999px;
+	background: var(--panel-strong);
+	color: var(--text);
+	border: 1px solid var(--line-soft);
 	font: inherit;
+	font-weight: 700;
+	font-size: 14px;
 	cursor: pointer;
-	border: 1px solid var(--line-soft, rgba(116, 92, 68, 0.14));
-	margin: 0;
 	transition:
 		transform 160ms ease,
-		border-color 160ms ease,
-		background 160ms ease;
+		background 0.3s ease,
+		color 0.3s ease,
+		border-color 0.3s ease;
 }
 
-.prediction-ghost-button.el-button {
-	background: var(--panel-strong, rgba(255, 253, 250, 0.8));
-	color: var(--text-color, #1f2328);
-}
-
-.prediction-primary-button.el-button {
-	background: var(--accent-color, #af6542);
-	color: #fffaf3;
-	border: none;
-	box-shadow: 0 16px 30px var(--accent-shadow, rgba(175, 101, 66, 0.24));
-}
-
-.prediction-reset-button.el-button {
-	background: transparent;
-	color: var(--text-color, #1f2328);
-}
-
-.prediction-ghost-button.el-button:hover,
-.prediction-primary-button.el-button:hover,
-.prediction-reset-button.el-button:hover,
-.prediction-language-toggle .el-button:hover {
+.prediction-ghost-btn:hover {
 	transform: translateY(-1px);
 }
 
-.prediction-primary-button.el-button.is-disabled,
-.prediction-reset-button.el-button.is-disabled {
-	opacity: 0.6;
-	cursor: progress;
+.prediction-ghost-btn:active {
+	transform: translateY(0);
 }
 
+.prediction-ghost-btn.is-active {
+	background: var(--accent);
+	color: var(--btn-text);
+	border-color: transparent;
+}
+
+/* Layout */
 .prediction-layout {
 	display: grid;
 	grid-template-columns: minmax(0, 0.94fr) minmax(0, 1.06fr);
@@ -186,39 +230,41 @@ a {
 	align-items: start;
 }
 
-.prediction-card,
-.prediction-results-card {
-	animation: prediction-fade-up 0.55s ease both;
-}
-
-.prediction-results-card {
-	animation-delay: 0.08s;
-}
-
+/* Cards */
 .prediction-card {
 	border-radius: 30px;
-	border: 1px solid var(--line-soft, rgba(116, 92, 68, 0.14));
-	background: var(--panel-bg, rgba(255, 251, 246, 0.68));
+	border: 1px solid var(--line-soft);
+	background: var(--panel-bg);
 	backdrop-filter: blur(18px);
-	box-shadow: 0 24px 70px var(--panel-shadow, rgba(110, 84, 63, 0.12));
+	-webkit-backdrop-filter: blur(18px);
+	box-shadow: 0 24px 70px var(--shadow);
+	transition:
+		background 0.3s ease,
+		border-color 0.3s ease,
+		box-shadow 0.3s ease;
+	animation: prediction-fade-up 0.55s ease both;
 }
 
 .prediction-card-inner {
 	display: grid;
 	gap: 22px;
-}
-
-.prediction-card.el-card,
-.prediction-results-card.el-card,
-.prediction-price-panel.el-card,
-.prediction-chart-summary-card.el-card {
-	overflow: hidden;
-}
-
-.prediction-card.el-card > .el-card__body {
 	padding: 22px;
 }
 
+.prediction-results-card {
+	border-radius: 30px;
+	border: 1px solid var(--line-soft);
+	background: var(--gradient-results);
+	box-shadow: 0 24px 70px var(--shadow);
+	padding: 22px;
+	transition:
+		background 0.3s ease,
+		border-color 0.3s ease,
+		box-shadow 0.3s ease;
+	animation: prediction-fade-up 0.55s ease 0.08s both;
+}
+
+/* Headline */
 .prediction-intro-block {
 	display: grid;
 	gap: 20px;
@@ -227,93 +273,112 @@ a {
 .prediction-headline {
 	margin: 0;
 	max-width: 10ch;
-	color: var(--text-color, #1f2328);
+	color: var(--text);
 	font-family: var(--font-display), var(--font-body), 'PingFang SC', 'Noto Sans SC', sans-serif;
 	font-size: clamp(3rem, 6vw, 5.3rem);
 	line-height: 0.9;
 	font-weight: 700;
 	letter-spacing: -0.04em;
+	transition: color 0.3s ease;
 }
 
 .prediction-headline-cjk {
-	max-width: none;
+	font-family: var(--font-body-cjk);
+	font-weight: 800;
 	letter-spacing: -0.02em;
 	line-height: 1.02;
+	max-width: none;
 }
 
 .prediction-lead {
 	max-width: 38rem;
 	margin: 0;
-	color: var(--text-muted, #72695f);
+	color: var(--text-muted);
 	font-size: 1rem;
 	line-height: 1.8;
+	transition: color 0.3s ease;
 }
 
 .prediction-caption {
 	margin: 0;
-	color: var(--text-muted, #72695f);
+	color: var(--text-muted);
 	font-size: 0.82rem;
 	line-height: 1.7;
+	transition: color 0.3s ease;
 }
 
-.prediction-figure-row,
-.prediction-results-grid,
-.prediction-chart-summary-grid {
+/* Figures */
+.prediction-figure-row {
 	display: grid;
-	grid-template-columns: repeat(3, minmax(0, 1fr));
+	grid-template-columns: repeat(3, 1fr);
 	gap: 10px;
 }
 
-.prediction-figure,
-.prediction-metric-card,
-.prediction-chart-summary-card {
-	padding: 16px;
-	border: 1px solid var(--line-soft, rgba(116, 92, 68, 0.14));
+.prediction-figure {
+	padding: 16px 16px 18px;
+	border: 1px solid var(--line-soft);
 	border-radius: 20px;
-	background: var(--panel-strong, rgba(255, 253, 250, 0.8));
+	background: var(--panel-strong);
+	transition:
+		background 0.3s ease,
+		border-color 0.3s ease;
 }
 
 .prediction-figure-label,
 .prediction-results-label,
-.prediction-metric-card span,
+.prediction-metric-label,
 .prediction-chart-kicker,
-.prediction-chart-summary-card span,
-.prediction-chart-summary-card small {
+.prediction-chart-summary-card span:first-child {
 	display: block;
-	color: var(--text-muted, #72695f);
+	color: var(--text-muted);
 	font-size: 10px;
 	font-weight: 800;
 	text-transform: uppercase;
 	letter-spacing: 1.2px;
+	transition: color 0.3s ease;
+}
+
+.prediction-results-label {
+	letter-spacing: 1.4px;
+}
+
+.prediction-chart-kicker {
+	letter-spacing: 1.3px;
 }
 
 .prediction-figure-value {
 	display: block;
 	margin-top: 6px;
-	color: var(--primary-color, #234b61);
+	color: var(--primary);
 	font-size: 1.85rem;
 	font-weight: 800;
 	letter-spacing: -0.04em;
+	transition: color 0.3s ease;
 }
 
+/* Form */
 .prediction-form-shell {
 	padding: 22px;
 	border-radius: 24px;
-	background: var(--panel-strong, rgba(255, 253, 250, 0.82));
-	border: 1px solid var(--line-soft, rgba(116, 92, 68, 0.14));
+	background: var(--panel-strong);
+	border: 1px solid var(--line-soft);
+	transition:
+		background 0.3s ease,
+		border-color 0.3s ease;
 }
 
 .prediction-section-title {
 	margin: 0 0 16px;
-	color: var(--primary-color, #234b61);
+	color: var(--primary);
 	font-size: 1.35rem;
 	font-weight: 800;
 	letter-spacing: -0.02em;
+	transition: color 0.3s ease;
 }
 
 .prediction-form-grid {
 	display: grid;
-	grid-template-columns: repeat(2, minmax(0, 1fr));
+	grid-template-columns: repeat(2, 1fr);
 	gap: 14px 16px;
 }
 
@@ -321,47 +386,80 @@ a {
 	grid-column: 1 / -1;
 }
 
-.prediction-field {
-	margin-bottom: 14px;
-}
-
-.prediction-field .el-form-item__label {
-	padding-bottom: 8px;
-	color: var(--text-color, #1f2328);
+.prediction-field-label {
+	display: block;
+	margin-bottom: 8px;
+	color: var(--text);
 	font-size: 11px;
 	font-weight: 800;
 	text-transform: uppercase;
 	letter-spacing: 1.1px;
+	transition: color 0.3s ease;
 }
 
-.prediction-field .el-select,
-.prediction-field .el-input-number {
+.prediction-field-error {
+	display: block;
+	margin-top: 6px;
+	color: var(--accent);
+	font-size: 0.82rem;
+	line-height: 1.4;
+}
+
+.prediction-field-select,
+.prediction-field-input {
 	width: 100%;
-}
-
-.prediction-field .el-select__wrapper,
-.prediction-field .el-input-number .el-input__wrapper {
-	box-sizing: border-box;
+	padding: 14px 16px;
 	min-height: 52px;
-	background: var(--field-bg, rgba(255, 255, 255, 0.54));
-	color: var(--text-color, #1f2328);
-	box-shadow: 0 0 0 1px var(--line-soft, rgba(116, 92, 68, 0.14)) inset;
+	border: 1px solid var(--line-soft);
+	border-radius: 16px;
+	background: var(--field-bg);
+	color: var(--text);
+	font: inherit;
+	font-weight: 600;
+	outline: none;
+	appearance: none;
+	-webkit-appearance: none;
+	transition:
+		border-color 200ms ease,
+		box-shadow 200ms ease,
+		background 0.3s ease,
+		color 0.3s ease;
+	cursor: pointer;
 }
 
-.prediction-field .el-select__wrapper.is-focused,
-.prediction-field .el-input-number .el-input__wrapper.is-focus {
-	box-shadow:
-		0 0 0 1px var(--primary-color, #234b61) inset,
-		0 0 0 3px var(--focus-ring, rgba(35, 75, 97, 0.12));
+.prediction-field-select {
+	background-image: url("data:image/svg+xml,%3Csvg width='12' height='8' viewBox='0 0 12 8' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M1 1.5L6 6.5L11 1.5' stroke='%2374685b' stroke-width='1.5' stroke-linecap='round' stroke-linejoin='round'/%3E%3C/svg%3E");
+	background-repeat: no-repeat;
+	background-position: right 16px center;
+	padding-right: 40px;
+}
+
+[data-theme='dark'] .prediction-field-select {
+	background-image: url("data:image/svg+xml,%3Csvg width='12' height='8' viewBox='0 0 12 8' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M1 1.5L6 6.5L11 1.5' stroke='%239e998f' stroke-width='1.5' stroke-linecap='round' stroke-linejoin='round'/%3E%3C/svg%3E");
+}
+
+.prediction-field-select:hover,
+.prediction-field-input:hover {
+	border-color: var(--primary);
+}
+
+.prediction-field-select:focus,
+.prediction-field-input:focus {
+	border-color: var(--primary);
+	box-shadow: 0 0 0 3px var(--focus-ring);
+}
+
+.prediction-field-input::placeholder {
+	color: var(--text-muted);
+	font-weight: 500;
 }
 
 .prediction-unit-wrap {
 	display: grid;
-	grid-template-columns: minmax(0, 1fr) auto;
-	width: 100%;
+	grid-template-columns: 1fr auto;
 }
 
-.prediction-unit-wrap .el-input-number .el-input__wrapper {
+.prediction-unit-wrap .prediction-field-input {
 	border-radius: 16px 0 0 16px;
 }
 
@@ -370,46 +468,112 @@ a {
 	align-items: center;
 	justify-content: center;
 	padding: 0 18px;
-	border: 1px solid var(--line-soft, rgba(116, 92, 68, 0.14));
+	border: 1px solid var(--line-soft);
 	border-left: none;
 	border-radius: 0 16px 16px 0;
-	background: var(--field-bg, rgba(255, 255, 255, 0.54));
-	color: var(--text-muted, #72695f);
+	background: var(--field-bg);
+	color: var(--text-muted);
 	font-size: 0.88rem;
 	font-weight: 700;
+	transition:
+		background 0.3s ease,
+		border-color 0.3s ease,
+		color 0.3s ease;
 }
 
+/* Buttons */
 .prediction-button-row {
+	grid-column: 1 / -1;
 	display: grid;
-	grid-template-columns: repeat(2, minmax(0, 1fr));
+	grid-template-columns: 1fr 1fr;
 	gap: 10px;
+	margin-top: 4px;
+}
+
+.prediction-btn-primary {
+	min-height: 54px;
+	padding: 14px 28px;
+	border-radius: 999px;
+	background: var(--accent);
+	color: var(--btn-text);
+	border: none;
+	box-shadow: 0 16px 30px var(--accent-shadow);
+	font: inherit;
+	font-weight: 700;
+	font-size: 1rem;
+	cursor: pointer;
+	transition:
+		transform 160ms ease,
+		opacity 160ms ease,
+		background 0.3s ease,
+		box-shadow 0.3s ease;
+}
+
+.prediction-btn-primary:hover:not(:disabled) {
+	transform: translateY(-1px);
+}
+
+.prediction-btn-primary:active:not(:disabled) {
+	transform: translateY(0);
+}
+
+.prediction-btn-primary:disabled {
+	opacity: 0.6;
+	cursor: progress;
+}
+
+.prediction-btn-reset {
+	min-height: 54px;
+	padding: 14px 28px;
+	border-radius: 999px;
+	background: transparent;
+	color: var(--text);
+	border: 1px solid var(--line-soft);
+	font: inherit;
+	font-weight: 700;
+	font-size: 1rem;
+	cursor: pointer;
+	transition:
+		transform 160ms ease,
+		background 0.3s ease,
+		color 0.3s ease,
+		border-color 0.3s ease;
+}
+
+.prediction-btn-reset:hover:not(:disabled) {
+	transform: translateY(-1px);
+}
+
+.prediction-btn-reset:active:not(:disabled) {
+	transform: translateY(0);
+}
+
+.prediction-btn-reset:disabled {
+	opacity: 0.6;
+	cursor: not-allowed;
+}
+
+.prediction-loading-pulse {
+	animation: prediction-pulse 1s ease-in-out infinite alternate;
+}
+
+.prediction-error-banner {
 	margin-top: 16px;
+	padding: 12px 14px;
+	border-radius: 14px;
+	border: 1px solid rgba(175, 101, 66, 0.24);
+	background: rgba(175, 101, 66, 0.1);
+	color: var(--text);
+	font-size: 0.92rem;
+	line-height: 1.5;
 }
 
-.prediction-button-row .el-button {
-	width: 100%;
+[data-theme='dark'] .prediction-error-banner {
+	border-color: rgba(207, 139, 96, 0.28);
+	background: rgba(207, 139, 96, 0.14);
 }
 
-.prediction-error-alert {
-	margin-top: 16px;
-}
-
-.prediction-results-card {
-	border-radius: 30px;
-	border: 1px solid var(--line-soft, rgba(116, 92, 68, 0.14));
-	background:
-		linear-gradient(
-			180deg,
-			var(--results-bg, rgba(255, 251, 246, 0.82)) 0%,
-			var(--results-bg-2, rgba(251, 246, 239, 0.72)) 100%
-		);
-	box-shadow: 0 24px 70px var(--panel-shadow, rgba(110, 84, 63, 0.12));
-}
-
-.prediction-results-card.el-card > .el-card__body {
-	padding: 22px;
-}
-
+/* Results */
 .prediction-results-header {
 	display: flex;
 	justify-content: space-between;
@@ -420,123 +584,135 @@ a {
 
 .prediction-results-title {
 	margin: 6px 0 0;
-	color: var(--text-color, #1f2328);
+	color: var(--text);
 	font-family: var(--font-display), var(--font-body), 'PingFang SC', 'Noto Sans SC', sans-serif;
 	font-size: clamp(2.2rem, 4vw, 3.4rem);
 	line-height: 0.95;
 	font-weight: 700;
 	letter-spacing: -0.04em;
+	transition: color 0.3s ease;
 }
 
 .prediction-price-panel {
 	min-width: 220px;
-	border-radius: 22px;
-	background: var(--price-panel-bg, rgba(255, 255, 255, 0.45));
-	border: 1px solid var(--line-soft, rgba(116, 92, 68, 0.14));
-}
-
-.prediction-price-panel.el-card > .el-card__body {
 	padding: 18px 20px;
+	border-radius: 22px;
+	background: var(--price-panel-bg);
+	border: 1px solid var(--line-soft);
+	transition:
+		background 0.3s ease,
+		border-color 0.3s ease;
 }
 
-.prediction-price-panel .el-statistic__content {
+.prediction-price-value {
+	display: block;
 	margin-top: 8px;
-}
-
-.prediction-price-panel .el-statistic__number {
-	color: var(--accent-color, #af6542);
-	font-size: clamp(2rem, 4vw, 3rem);
+	color: var(--accent);
+	font-size: clamp(2rem, 4vw, 2.7rem);
 	font-weight: 800;
 	line-height: 1;
 	letter-spacing: -0.04em;
+	font-variant-numeric: tabular-nums;
+	transition: color 0.3s ease;
+}
+
+.prediction-price-value.has-value {
 	animation: prediction-settle 0.55s ease;
 }
 
-.prediction-pulse {
-	animation: prediction-pulse 1s ease-in-out infinite alternate;
+.prediction-price-value.awaiting {
+	color: var(--text-muted);
+	font-size: clamp(1.1rem, 2vw, 1.3rem);
+	letter-spacing: -0.02em;
 }
 
-.prediction-results-grid.el-descriptions {
+.prediction-metric-grid {
+	display: grid;
+	grid-template-columns: repeat(3, 1fr);
+	gap: 10px;
 	margin-bottom: 18px;
 }
 
-.prediction-results-grid .el-descriptions__label {
-	color: var(--text-muted, #72695f);
-	font-size: 10px;
-	font-weight: 800;
-	text-transform: uppercase;
-	letter-spacing: 1.2px;
+.prediction-metric-card {
+	padding: 14px 16px;
+	border: 1px solid var(--line-soft);
+	border-radius: 18px;
+	background: var(--panel-strong);
+	transition:
+		background 0.3s ease,
+		border-color 0.3s ease;
 }
 
-.prediction-results-grid .el-descriptions__content,
-.prediction-metric-card strong,
-.prediction-chart-summary-card strong {
-	color: var(--text-color, #1f2328);
+.prediction-metric-value {
+	display: block;
+	margin-top: 6px;
+	color: var(--text);
 	font-size: 0.95rem;
 	font-weight: 700;
 	line-height: 1.45;
+	transition: color 0.3s ease;
 }
 
+/* Chart */
 .prediction-chart-shell {
-	padding-top: 12px;
-	border-top: 1px solid var(--line-soft, rgba(116, 92, 68, 0.14));
-}
-
-.prediction-results-card .el-divider {
-	margin: 18px 0 16px;
-	border-color: var(--line-soft, rgba(116, 92, 68, 0.14));
-}
-
-.prediction-chart-header {
-	display: grid;
-	gap: 14px;
-	margin-bottom: 14px;
-}
-
-.prediction-chart-copy {
-	max-width: 34rem;
+	padding-top: 16px;
+	border-top: 1px solid var(--line-soft);
+	transition: border-color 0.3s ease;
 }
 
 .prediction-chart-title {
-	margin: 6px 0 0;
-	color: var(--text-color, #1f2328);
+	margin: 6px 0 14px;
+	color: var(--text);
 	font-size: 1.2rem;
 	font-weight: 800;
 	letter-spacing: -0.03em;
+	transition: color 0.3s ease;
+}
+
+.prediction-chart-summary-grid {
+	display: grid;
+	grid-template-columns: repeat(3, 1fr);
+	gap: 10px;
+	margin-bottom: 14px;
 }
 
 .prediction-chart-summary-card {
-	min-width: 130px;
-	border-radius: 18px;
-	background: var(--panel-strong, rgba(255, 255, 255, 0.48));
-}
-
-.prediction-chart-summary-card.el-card > .el-card__body {
 	padding: 12px 14px;
+	border: 1px solid var(--line-soft);
+	border-radius: 18px;
+	background: var(--panel-strong);
+	transition:
+		background 0.3s ease,
+		border-color 0.3s ease;
 }
 
-.prediction-chart-summary-card strong {
+.prediction-chart-summary-val {
 	display: block;
 	margin-top: 6px;
+	color: var(--text);
+	font-size: 1rem;
+	font-weight: 800;
+	letter-spacing: -0.03em;
+	font-variant-numeric: tabular-nums;
 	overflow-wrap: anywhere;
+	transition: color 0.3s ease;
 }
 
-.prediction-chart-summary-card small {
+.prediction-chart-summary-sub {
+	display: block;
 	margin-top: 4px;
+	color: var(--text-muted);
 	font-size: 9px;
+	font-weight: 800;
+	text-transform: uppercase;
+	letter-spacing: 1.2px;
+	transition: color 0.3s ease;
 }
 
 .prediction-chart-frame {
-	height: 320px;
-	display: flex;
-	align-items: center;
-	justify-content: center;
-	border-radius: 20px;
-	background: linear-gradient(
-		180deg,
-		color-mix(in srgb, var(--panel-strong, rgba(255, 255, 255, 0.48)) 88%, transparent) 0%,
-		color-mix(in srgb, var(--price-panel-bg, rgba(255, 255, 255, 0.45)) 72%, transparent) 100%
-	);
+	position: relative;
+	min-height: 300px;
+	height: 300px;
 }
 
 .prediction-chart-frame canvas {
@@ -545,6 +721,40 @@ a {
 	display: block;
 }
 
+/* Placeholder */
+.prediction-placeholder {
+	padding: 28px;
+	min-height: 220px;
+	border-radius: 24px;
+	border: 1px dashed var(--line-soft);
+	background: var(--panel-strong);
+	display: grid;
+	gap: 10px;
+	align-content: start;
+	transition:
+		background 0.3s ease,
+		border-color 0.3s ease;
+}
+
+.prediction-placeholder-title {
+	margin: 0;
+	color: var(--text);
+	font-size: 1.35rem;
+	font-weight: 800;
+	letter-spacing: -0.03em;
+	transition: color 0.3s ease;
+}
+
+.prediction-placeholder-body {
+	margin: 0;
+	max-width: 42ch;
+	color: var(--text-muted);
+	font-size: 0.98rem;
+	line-height: 1.7;
+	transition: color 0.3s ease;
+}
+
+/* Animations */
 @keyframes prediction-fade-up {
 	from {
 		transform: translateY(18px);
@@ -579,6 +789,7 @@ a {
 	}
 }
 
+/* Responsive */
 @media (max-width: 1080px) {
 	.prediction-layout {
 		grid-template-columns: 1fr;
@@ -605,7 +816,7 @@ a {
 
 	.prediction-form-grid,
 	.prediction-figure-row,
-	.prediction-results-grid,
+	.prediction-metric-grid,
 	.prediction-button-row,
 	.prediction-chart-summary-grid {
 		grid-template-columns: 1fr;
@@ -620,6 +831,7 @@ a {
 	}
 
 	.prediction-chart-frame {
+		min-height: 280px;
 		height: 280px;
 	}
 }

--- a/app/assets/styles/prediction.css
+++ b/app/assets/styles/prediction.css
@@ -127,7 +127,6 @@ a {
 	mask-image: radial-gradient(circle at center, black 40%, transparent 88%);
 	-webkit-mask-image: radial-gradient(circle at center, black 40%, transparent 88%);
 	opacity: 0.22;
-	transition: background-image 0.45s ease;
 }
 
 .prediction-shell::after {
@@ -424,11 +423,11 @@ a {
 		box-shadow 200ms ease,
 		background 0.3s ease,
 		color 0.3s ease;
-	cursor: pointer;
 }
 
 /* Chevron stroke colors mirror --text-muted (light #74685b, dark #9e998f); data URIs cannot use CSS variables. */
 .prediction-field-select {
+	cursor: pointer;
 	background-image: url("data:image/svg+xml,%3Csvg width='12' height='8' viewBox='0 0 12 8' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M1 1.5L6 6.5L11 1.5' stroke='%2374685b' stroke-width='1.5' stroke-linecap='round' stroke-linejoin='round'/%3E%3C/svg%3E");
 	background-repeat: no-repeat;
 	background-position: right 16px center;

--- a/app/components/prediction/PredictionForm.vue
+++ b/app/components/prediction/PredictionForm.vue
@@ -31,190 +31,236 @@ function updateField<K extends keyof FieldType>(key: K, value: FieldType[K]) {
 		value
 	});
 }
-
-function updateNumberField<K extends 'floor_area_sqm' | 'lease_commence_date'>(
-	key: K,
-	value: number | null | undefined
-) {
-	updateField(key, Number(value ?? 0) as FieldType[K]);
-}
 </script>
 
 <template>
-	<el-card class="prediction-card prediction-form-card" shadow="never">
-		<div class="prediction-card-inner">
-			<div class="prediction-intro-block">
-				<h1
-					:class="[
-						'prediction-headline',
-						currentLang === 'zh' ? 'prediction-headline-cjk' : ''
-					]"
-				>
-					{{ tr('price_prediction') }}
-				</h1>
-				<p class="prediction-lead">{{ tr('intro_blurb') }}</p>
-
-				<div class="prediction-figure-row">
-					<div class="prediction-figure">
-						<span class="prediction-figure-label">{{ tr('ml_model') }}</span>
-						<strong class="prediction-figure-value">
-							{{ String(ML_MODELS.length).padStart(2, '0') }}
-						</strong>
-					</div>
-					<div class="prediction-figure">
-						<span class="prediction-figure-label">{{ tr('town') }}</span>
-						<strong class="prediction-figure-value">
-							{{ String(TOWNS.length).padStart(2, '0') }}
-						</strong>
-					</div>
-					<div class="prediction-figure">
-						<span class="prediction-figure-label">{{ tr('flat_model') }}</span>
-						<strong class="prediction-figure-value">
-							{{ String(FLAT_MODELS.length).padStart(2, '0') }}
-						</strong>
-					</div>
-				</div>
-
-				<p class="prediction-caption">{{ tr('intro_caption') }}</p>
-			</div>
-
-			<el-form class="prediction-form-shell" label-position="top" @submit.prevent="emit('submit')">
-				<h2 class="prediction-section-title">{{ tr('prediction_form') }}</h2>
-
-				<div class="prediction-form-grid">
-					<el-form-item
-						class="prediction-field"
-						:label="tr('ml_model')"
-						:error="fieldErrors.ml_model"
+	<section>
+		<div class="prediction-card">
+			<div class="prediction-card-inner">
+				<div class="prediction-intro-block">
+					<h1
+						:class="[
+							'prediction-headline',
+							currentLang === 'zh' ? 'prediction-headline-cjk' : ''
+						]"
 					>
-						<el-select
-							:model-value="form.ml_model"
-							@update:model-value="updateField('ml_model', $event)"
-						>
-							<el-option
-								v-for="mlModel in ML_MODELS"
-								:key="mlModel"
-								:label="optionLabel('ml_models', mlModel)"
-								:value="mlModel"
-							/>
-						</el-select>
-					</el-form-item>
+						{{ tr('price_prediction') }}
+					</h1>
+					<p class="prediction-lead">{{ tr('intro_blurb') }}</p>
 
-					<el-form-item class="prediction-field" :label="tr('town')" :error="fieldErrors.town">
-						<el-select
-							:model-value="form.town"
-							@update:model-value="updateField('town', $event)"
-						>
-							<el-option
-								v-for="town in TOWNS"
-								:key="town"
-								:label="optionLabel('towns', town)"
-								:value="town"
-							/>
-						</el-select>
-					</el-form-item>
-
-					<el-form-item
-						class="prediction-field"
-						:label="tr('storey_range')"
-						:error="fieldErrors.storey_range"
-					>
-						<el-select
-							:model-value="form.storey_range"
-							@update:model-value="updateField('storey_range', $event)"
-						>
-							<el-option
-								v-for="storeyRange in STOREY_RANGES"
-								:key="storeyRange"
-								:label="optionLabel('storey_ranges', storeyRange)"
-								:value="storeyRange"
-							/>
-						</el-select>
-					</el-form-item>
-
-					<el-form-item
-						class="prediction-field"
-						:label="tr('flat_model')"
-						:error="fieldErrors.flat_model"
-					>
-						<el-select
-							:model-value="form.flat_model"
-							@update:model-value="updateField('flat_model', $event)"
-						>
-							<el-option
-								v-for="flatModel in FLAT_MODELS"
-								:key="flatModel"
-								:label="optionLabel('flat_models', flatModel)"
-								:value="flatModel"
-							/>
-						</el-select>
-					</el-form-item>
-
-					<el-form-item
-						class="prediction-field prediction-field-full"
-						:label="tr('floor_area')"
-						:error="fieldErrors.floor_area_sqm"
-					>
-						<div class="prediction-unit-wrap">
-							<el-input-number
-								:model-value="form.floor_area_sqm"
-								:min="20"
-								:max="300"
-								:step="1"
-								:precision="0"
-								:controls="false"
-								@update:model-value="updateNumberField('floor_area_sqm', $event)"
-							/>
-							<div class="prediction-unit-tag">m²</div>
+					<div class="prediction-figure-row">
+						<div class="prediction-figure">
+							<span class="prediction-figure-label">{{ tr('ml_model') }}</span>
+							<strong class="prediction-figure-value">
+								{{ String(ML_MODELS.length).padStart(2, '0') }}
+							</strong>
 						</div>
-					</el-form-item>
+						<div class="prediction-figure">
+							<span class="prediction-figure-label">{{ tr('town') }}</span>
+							<strong class="prediction-figure-value">
+								{{ String(TOWNS.length).padStart(2, '0') }}
+							</strong>
+						</div>
+						<div class="prediction-figure">
+							<span class="prediction-figure-label">{{ tr('flat_model') }}</span>
+							<strong class="prediction-figure-value">
+								{{ String(FLAT_MODELS.length).padStart(2, '0') }}
+							</strong>
+						</div>
+					</div>
 
-					<el-form-item
-						class="prediction-field prediction-field-full"
-						:label="tr('lease_commence_date')"
-						:error="fieldErrors.lease_commence_date"
-					>
-						<el-select
-							:model-value="form.lease_commence_date"
-							@update:model-value="updateNumberField('lease_commence_date', $event)"
-						>
-							<el-option
-								v-for="year in YEAR_OPTIONS"
-								:key="year"
-								:label="String(year)"
-								:value="year"
-							/>
-						</el-select>
-					</el-form-item>
+					<p class="prediction-caption">{{ tr('intro_caption') }}</p>
 				</div>
 
-				<div class="prediction-button-row">
-					<el-button
-						class="prediction-primary-button"
-						type="primary"
-						native-type="submit"
-						:loading="loading"
-					>
-						{{ tr('get_prediction') }}
-					</el-button>
-					<el-button
-						class="prediction-reset-button"
-						:disabled="loading"
-						@click="emit('reset')"
-					>
-						{{ tr('reset_form') }}
-					</el-button>
-				</div>
+				<div class="prediction-form-shell">
+					<h2 class="prediction-section-title">{{ tr('prediction_form') }}</h2>
 
-				<el-alert
-					v-if="errorMessage"
-					class="prediction-error-alert"
-					:title="errorMessage"
-					type="error"
-					:closable="false"
-					show-icon
-				/>
-			</el-form>
+					<form @submit.prevent="emit('submit')">
+						<div class="prediction-form-grid">
+							<div>
+								<label class="prediction-field-label" for="input-ml_model">
+									{{ tr('ml_model') }}
+								</label>
+								<select
+									id="input-ml_model"
+									class="prediction-field-select"
+									:value="form.ml_model"
+									@change="
+										updateField(
+											'ml_model',
+											($event.target as HTMLSelectElement).value as FieldType['ml_model']
+										)
+									"
+								>
+									<option v-for="mlModel in ML_MODELS" :key="mlModel" :value="mlModel">
+										{{ optionLabel('ml_models', mlModel) }}
+									</option>
+								</select>
+								<span v-if="fieldErrors.ml_model" class="prediction-field-error">
+									{{ fieldErrors.ml_model }}
+								</span>
+							</div>
+
+							<div>
+								<label class="prediction-field-label" for="input-town">
+									{{ tr('town') }}
+								</label>
+								<select
+									id="input-town"
+									class="prediction-field-select"
+									:value="form.town"
+									@change="
+										updateField(
+											'town',
+											($event.target as HTMLSelectElement).value as FieldType['town']
+										)
+									"
+								>
+									<option v-for="town in TOWNS" :key="town" :value="town">
+										{{ optionLabel('towns', town) }}
+									</option>
+								</select>
+								<span v-if="fieldErrors.town" class="prediction-field-error">
+									{{ fieldErrors.town }}
+								</span>
+							</div>
+
+							<div>
+								<label class="prediction-field-label" for="input-storey_range">
+									{{ tr('storey_range') }}
+								</label>
+								<select
+									id="input-storey_range"
+									class="prediction-field-select"
+									:value="form.storey_range"
+									@change="
+										updateField(
+											'storey_range',
+											($event.target as HTMLSelectElement)
+												.value as FieldType['storey_range']
+										)
+									"
+								>
+									<option
+										v-for="storeyRange in STOREY_RANGES"
+										:key="storeyRange"
+										:value="storeyRange"
+									>
+										{{ optionLabel('storey_ranges', storeyRange) }}
+									</option>
+								</select>
+								<span v-if="fieldErrors.storey_range" class="prediction-field-error">
+									{{ fieldErrors.storey_range }}
+								</span>
+							</div>
+
+							<div>
+								<label class="prediction-field-label" for="input-flat_model">
+									{{ tr('flat_model') }}
+								</label>
+								<select
+									id="input-flat_model"
+									class="prediction-field-select"
+									:value="form.flat_model"
+									@change="
+										updateField(
+											'flat_model',
+											($event.target as HTMLSelectElement)
+												.value as FieldType['flat_model']
+										)
+									"
+								>
+									<option
+										v-for="flatModel in FLAT_MODELS"
+										:key="flatModel"
+										:value="flatModel"
+									>
+										{{ optionLabel('flat_models', flatModel) }}
+									</option>
+								</select>
+								<span v-if="fieldErrors.flat_model" class="prediction-field-error">
+									{{ fieldErrors.flat_model }}
+								</span>
+							</div>
+
+							<div class="prediction-field-full">
+								<label class="prediction-field-label" for="input-floor_area">
+									{{ tr('floor_area') }}
+								</label>
+								<div class="prediction-unit-wrap">
+									<input
+										id="input-floor_area"
+										type="number"
+										class="prediction-field-input"
+										min="20"
+										max="300"
+										step="1"
+										:value="form.floor_area_sqm"
+										:placeholder="tr('enter_floor_area')"
+										@input="
+											updateField(
+												'floor_area_sqm',
+												Number(($event.target as HTMLInputElement).value)
+											)
+										"
+									>
+									<span class="prediction-unit-tag">m²</span>
+								</div>
+								<span v-if="fieldErrors.floor_area_sqm" class="prediction-field-error">
+									{{ fieldErrors.floor_area_sqm }}
+								</span>
+							</div>
+
+							<div class="prediction-field-full">
+								<label class="prediction-field-label" for="input-lease_year">
+									{{ tr('lease_commence_date') }}
+								</label>
+								<select
+									id="input-lease_year"
+									class="prediction-field-select"
+									:value="form.lease_commence_date"
+									@change="
+										updateField(
+											'lease_commence_date',
+											Number(($event.target as HTMLSelectElement).value)
+										)
+									"
+								>
+									<option v-for="year in YEAR_OPTIONS" :key="year" :value="year">
+										{{ year }}
+									</option>
+								</select>
+								<span v-if="fieldErrors.lease_commence_date" class="prediction-field-error">
+									{{ fieldErrors.lease_commence_date }}
+								</span>
+							</div>
+
+							<div class="prediction-button-row">
+								<button
+									type="submit"
+									class="prediction-btn-primary"
+									:class="{ 'prediction-loading-pulse': loading }"
+									:disabled="loading"
+								>
+									{{ loading ? tr('predicting') : tr('get_prediction') }}
+								</button>
+								<button
+									type="button"
+									class="prediction-btn-reset"
+									:disabled="loading"
+									@click="emit('reset')"
+								>
+									{{ tr('reset_form') }}
+								</button>
+							</div>
+						</div>
+
+						<p v-if="errorMessage" class="prediction-error-banner" role="alert">
+							{{ errorMessage }}
+						</p>
+					</form>
+				</div>
+			</div>
 		</div>
-	</el-card>
+	</section>
 </template>

--- a/app/components/prediction/PredictionPage.vue
+++ b/app/components/prediction/PredictionPage.vue
@@ -1,7 +1,5 @@
 <script setup lang="ts">
-import { computed, onBeforeUnmount, onMounted, reactive, ref, watch } from 'vue';
-import en from 'element-plus/es/locale/lang/en';
-import zhCn from 'element-plus/es/locale/lang/zh-cn';
+import { computed, onMounted, reactive, ref, watch } from 'vue';
 
 import PredictionForm from '~/components/prediction/PredictionForm.vue';
 import PredictionResults from '~/components/prediction/PredictionResults.vue';
@@ -24,7 +22,6 @@ const loading = ref(false);
 const errorMessage = ref('');
 const darkMode = ref(false);
 const currentLang = ref<Language>('en');
-const isMobile = ref(false);
 const isHydrated = ref(false);
 const skipNextPersist = ref(false);
 
@@ -37,43 +34,19 @@ const fieldErrors = reactive<Record<keyof FieldType, string>>({
 	lease_commence_date: ''
 });
 
-const theme = computed(() => getPredictionTheme(darkMode.value));
-const summaryValues = computed(() => ({
+const summaryValues = ref({
 	ml_model: form.value.ml_model,
 	town: form.value.town,
 	lease_commence_date: form.value.lease_commence_date
-}));
-const elementLocale = computed(() => (currentLang.value === 'zh' ? zhCn : en));
+});
 
-const pageStyle = computed<Record<string, string>>(() => ({
-	'--page-bg': theme.value.pageBg,
-	'--text-color': theme.value.text,
-	'--text-muted': theme.value.textMuted,
-	'--primary-color': theme.value.primary,
-	'--accent-color': theme.value.accent,
-	'--line-soft': theme.value.lineSoft,
-	'--panel-bg': theme.value.panelBg,
-	'--panel-strong': theme.value.panelStrong,
-	'--results-bg': theme.value.resultsBg,
-	'--results-bg-2': theme.value.resultsBg2,
-	'--price-panel-bg': theme.value.pricePanelBg,
-	'--field-bg': theme.value.fieldBg,
-	'--pill-bg': theme.value.pillBg,
-	'--focus-ring': theme.value.focusRing,
-	'--panel-shadow': theme.value.shadow,
-	'--accent-shadow': theme.value.accentShadow,
-	'--mesh-line': theme.value.meshLine,
-	'--orb-color': theme.value.orbColor,
-	background: theme.value.background
-}));
+const theme = computed(() => getPredictionTheme(darkMode.value));
 
 useHead(() => ({
 	title: tr('price_prediction'),
 	htmlAttrs: {
 		lang: currentLang.value,
-		'data-lang': currentLang.value
-	},
-	bodyAttrs: {
+		'data-lang': currentLang.value,
 		'data-theme': darkMode.value ? 'dark' : 'light'
 	}
 }));
@@ -86,14 +59,6 @@ function clearErrors() {
 	for (const key of Object.keys(fieldErrors) as Array<keyof FieldType>) {
 		fieldErrors[key] = '';
 	}
-}
-
-function setViewportFlags() {
-	if (!import.meta.client) {
-		return;
-	}
-
-	isMobile.value = window.innerWidth < 900;
 }
 
 function restoreFromStorage() {
@@ -194,6 +159,11 @@ function resetForm() {
 	output.value = 0;
 	errorMessage.value = '';
 	clearErrors();
+	summaryValues.value = {
+		ml_model: form.value.ml_model,
+		town: form.value.town,
+		lease_commence_date: form.value.lease_commence_date
+	};
 
 	if (import.meta.client) {
 		localStorage.removeItem('form');
@@ -242,6 +212,11 @@ async function handleSubmit() {
 	}
 
 	loading.value = true;
+	summaryValues.value = {
+		ml_model: form.value.ml_model,
+		town: form.value.town,
+		lease_commence_date: form.value.lease_commence_date
+	};
 
 	try {
 		const { monthStart, monthEnd } = getPredictionWindow();
@@ -303,75 +278,61 @@ watch(form, (value) => {
 });
 
 onMounted(() => {
-	setViewportFlags();
 	restoreFromStorage();
 	isHydrated.value = true;
-
-	if (import.meta.client) {
-		window.addEventListener('resize', setViewportFlags);
-	}
-});
-
-onBeforeUnmount(() => {
-	if (import.meta.client) {
-		window.removeEventListener('resize', setViewportFlags);
-	}
 });
 </script>
 
 <template>
-	<el-config-provider :locale="elementLocale" size="large">
-		<main class="prediction-shell" :style="pageStyle">
-			<div class="prediction-surface">
-				<div class="prediction-topbar">
-					<el-tag class="prediction-pill" effect="plain" round>
-						{{ tr('intro_eyebrow') }}
-					</el-tag>
+	<main class="prediction-shell">
+		<div class="prediction-surface">
+			<div class="prediction-topbar">
+				<div class="prediction-pill">{{ tr('intro_eyebrow') }}</div>
 
-					<div class="prediction-actions">
-						<el-button class="prediction-ghost-button" @click="toggleTheme">
-							{{ darkMode ? 'Light' : 'Dark' }}
-						</el-button>
-						<el-button-group class="prediction-language-toggle">
-							<el-button
-								:type="currentLang === 'en' ? 'primary' : 'default'"
-								@click="setLanguage('en')"
-							>
-								EN
-							</el-button>
-							<el-button
-								:type="currentLang === 'zh' ? 'primary' : 'default'"
-								@click="setLanguage('zh')"
-							>
-								中文
-							</el-button>
-						</el-button-group>
-					</div>
-				</div>
-
-				<div class="prediction-layout">
-					<PredictionForm
-						:form="form"
-						:field-errors="fieldErrors"
-						:loading="loading"
-						:current-lang="currentLang"
-						:error-message="errorMessage"
-						@submit="handleSubmit"
-						@reset="resetForm"
-						@update-field="updateField"
-					/>
-
-					<PredictionResults
-						:output="output"
-						:loading="loading"
-						:summary-values="summaryValues"
-						:trend-data="trendData"
-						:theme="theme"
-						:is-mobile="isMobile"
-						:current-lang="currentLang"
-					/>
+				<div class="prediction-actions">
+					<button type="button" class="prediction-ghost-btn" @click="toggleTheme">
+						{{ darkMode ? 'Light' : 'Dark' }}
+					</button>
+					<button
+						type="button"
+						class="prediction-ghost-btn"
+						:class="{ 'is-active': currentLang === 'en' }"
+						@click="setLanguage('en')"
+					>
+						EN
+					</button>
+					<button
+						type="button"
+						class="prediction-ghost-btn"
+						:class="{ 'is-active': currentLang === 'zh' }"
+						@click="setLanguage('zh')"
+					>
+						中文
+					</button>
 				</div>
 			</div>
-		</main>
-	</el-config-provider>
+
+			<div class="prediction-layout">
+				<PredictionForm
+					:form="form"
+					:field-errors="fieldErrors"
+					:loading="loading"
+					:current-lang="currentLang"
+					:error-message="errorMessage"
+					@submit="handleSubmit"
+					@reset="resetForm"
+					@update-field="updateField"
+				/>
+
+				<PredictionResults
+					:output="output"
+					:loading="loading"
+					:summary-values="summaryValues"
+					:trend-data="trendData"
+					:theme="theme"
+					:current-lang="currentLang"
+				/>
+			</div>
+		</div>
+	</main>
 </template>

--- a/app/components/prediction/PredictionPage.vue
+++ b/app/components/prediction/PredictionPage.vue
@@ -17,6 +17,7 @@ import {
 
 const form = ref<FieldType>({ ...initialFormValues });
 const output = ref(0);
+const hasPrediction = ref(false);
 const trendData = ref(defaultTrendData());
 const loading = ref(false);
 const errorMessage = ref('');
@@ -157,6 +158,7 @@ function resetForm() {
 	form.value = { ...initialFormValues };
 	trendData.value = defaultTrendData();
 	output.value = 0;
+	hasPrediction.value = false;
 	errorMessage.value = '';
 	clearErrors();
 	summaryValues.value = {
@@ -244,6 +246,7 @@ async function handleSubmit() {
 		const serverData = normalizeTrendData(await response.json());
 		trendData.value = serverData;
 		output.value = normalizePrice(serverData[serverData.length - 1]?.value ?? 0);
+		hasPrediction.value = true;
 	} catch (error) {
 		errorMessage.value =
 			error instanceof Error && error.message ? error.message : tr('error_fetch');
@@ -326,6 +329,7 @@ onMounted(() => {
 
 				<PredictionResults
 					:output="output"
+					:has-prediction="hasPrediction"
 					:loading="loading"
 					:summary-values="summaryValues"
 					:trend-data="trendData"

--- a/app/components/prediction/PredictionResults.vue
+++ b/app/components/prediction/PredictionResults.vue
@@ -12,9 +12,10 @@ const props = defineProps<{
 	summaryValues: SummaryValues;
 	trendData: TrendPoint[];
 	theme: PredictionTheme;
-	isMobile: boolean;
 	currentLang: Language;
 }>();
+
+const hasPrediction = computed(() => props.output > 0);
 
 const latestValue = computed(() => props.trendData[props.trendData.length - 1]?.value ?? 0);
 const firstValue = computed(() => props.trendData[0]?.value ?? 0);
@@ -38,75 +39,91 @@ function tr(key: string) {
 function optionLabel(group: 'ml_models' | 'towns' | 'storey_ranges' | 'flat_models', value: string) {
 	return translate(props.currentLang, `${group}.${value}`);
 }
+
+function formatPrice(value: number) {
+	return `$${Math.round(value).toLocaleString()}`;
+}
 </script>
 
 <template>
-	<el-card class="prediction-results-card" shadow="never">
-		<div class="prediction-results-header">
-			<div>
-				<span class="prediction-results-label">{{ tr('predicted_trends') }}</span>
-				<h2 class="prediction-results-title">{{ tr('predicted_price') }}</h2>
+	<section>
+		<div class="prediction-results-card">
+			<div class="prediction-results-header">
+				<div>
+					<span class="prediction-results-label">{{ tr('predicted_trends') }}</span>
+					<h2 class="prediction-results-title">{{ tr('predicted_price') }}</h2>
+				</div>
+
+				<div class="prediction-price-panel" :class="{ 'prediction-loading-pulse': loading }">
+					<span class="prediction-results-label">{{ tr('prediction') }}</span>
+					<strong
+						:key="output"
+						:class="[
+							'prediction-price-value',
+							hasPrediction ? 'has-value' : 'awaiting'
+						]"
+					>
+						{{ hasPrediction ? formatCurrency(output) : tr('awaiting') }}
+					</strong>
+				</div>
 			</div>
 
-			<el-card :class="['prediction-price-panel', { 'prediction-pulse': loading }]" shadow="never">
-				<el-statistic :value="output" :formatter="() => formatCurrency(output)">
-					<template #title>
-						<span class="prediction-results-label">{{ tr('prediction') }}</span>
-					</template>
-				</el-statistic>
-			</el-card>
-		</div>
-
-		<el-descriptions
-			class="prediction-results-grid"
-			:column="isMobile ? 1 : 3"
-			border
-			direction="vertical"
-		>
-			<el-descriptions-item :label="tr('ml_model')">
-				{{ optionLabel('ml_models', summaryValues.ml_model) }}
-			</el-descriptions-item>
-			<el-descriptions-item :label="tr('town')">
-				{{ optionLabel('towns', summaryValues.town) }}
-			</el-descriptions-item>
-			<el-descriptions-item :label="tr('lease_commence_date')">
-				{{ summaryValues.lease_commence_date }}
-			</el-descriptions-item>
-		</el-descriptions>
-
-		<el-divider />
-
-		<div class="prediction-chart-shell">
-			<div class="prediction-chart-header">
-				<div class="prediction-chart-copy">
-					<span class="prediction-chart-kicker">{{ tr('predicted_trends') }}</span>
-					<h3 class="prediction-chart-title">{{ tr('chart_story_title') }}</h3>
+			<div class="prediction-metric-grid">
+				<div class="prediction-metric-card">
+					<span class="prediction-metric-label">{{ tr('ml_model') }}</span>
+					<strong class="prediction-metric-value">
+						{{ optionLabel('ml_models', summaryValues.ml_model) }}
+					</strong>
 				</div>
+				<div class="prediction-metric-card">
+					<span class="prediction-metric-label">{{ tr('town') }}</span>
+					<strong class="prediction-metric-value">
+						{{ optionLabel('towns', summaryValues.town) }}
+					</strong>
+				</div>
+				<div class="prediction-metric-card">
+					<span class="prediction-metric-label">{{ tr('lease_commence_date') }}</span>
+					<strong class="prediction-metric-value">
+						{{ summaryValues.lease_commence_date }}
+					</strong>
+				</div>
+			</div>
+
+			<div v-if="hasPrediction" class="prediction-chart-shell">
+				<span class="prediction-chart-kicker">{{ tr('predicted_trends') }}</span>
+				<h3 class="prediction-chart-title">{{ tr('chart_story_title') }}</h3>
 
 				<div class="prediction-chart-summary-grid">
-					<el-card class="prediction-chart-summary-card" shadow="never">
+					<div class="prediction-chart-summary-card">
 						<span>{{ tr('chart_latest') }}</span>
-						<strong>{{ `$${latestValue.toLocaleString()}` }}</strong>
-					</el-card>
-					<el-card class="prediction-chart-summary-card" shadow="never">
+						<strong class="prediction-chart-summary-val">
+							{{ formatPrice(latestValue) }}
+						</strong>
+					</div>
+					<div class="prediction-chart-summary-card">
 						<span>{{ tr('chart_range') }}</span>
-						<strong>
-							{{ `$${normalizedLowValue.toLocaleString()} - $${peakValue.toLocaleString()}` }}
+						<strong class="prediction-chart-summary-val">
+							{{ formatPrice(normalizedLowValue) }} – {{ formatPrice(peakValue) }}
 						</strong>
-					</el-card>
-					<el-card class="prediction-chart-summary-card" shadow="never">
+					</div>
+					<div class="prediction-chart-summary-card">
 						<span>{{ tr('chart_delta') }}</span>
-						<strong>
-							{{ `${deltaValue >= 0 ? '+' : '-'}$${Math.abs(deltaValue).toLocaleString()}` }}
+						<strong class="prediction-chart-summary-val">
+							{{ deltaValue >= 0 ? '+' : '-' }}{{ formatPrice(Math.abs(deltaValue)) }}
 						</strong>
-						<small>{{ tr('vs_12m_ago') }}</small>
-					</el-card>
+						<span class="prediction-chart-summary-sub">{{ tr('vs_12m_ago') }}</span>
+					</div>
 				</div>
+
+				<ClientOnly>
+					<PriceTrendChart :data="trendData" :theme="theme" />
+				</ClientOnly>
 			</div>
 
-			<ClientOnly fallback-tag="div">
-				<PriceTrendChart :data="trendData" :theme="theme" :is-mobile="isMobile" />
-			</ClientOnly>
+			<div v-else class="prediction-placeholder">
+				<h3 class="prediction-placeholder-title">{{ tr('placeholder_title') }}</h3>
+				<p class="prediction-placeholder-body">{{ tr('placeholder_body') }}</p>
+			</div>
 		</div>
-	</el-card>
+	</section>
 </template>

--- a/app/components/prediction/PredictionResults.vue
+++ b/app/components/prediction/PredictionResults.vue
@@ -8,14 +8,13 @@ import type { PredictionTheme, SummaryValues, TrendPoint } from '~/utils/predict
 
 const props = defineProps<{
 	output: number;
+	hasPrediction: boolean;
 	loading: boolean;
 	summaryValues: SummaryValues;
 	trendData: TrendPoint[];
 	theme: PredictionTheme;
 	currentLang: Language;
 }>();
-
-const hasPrediction = computed(() => props.output > 0);
 
 const latestValue = computed(() => props.trendData[props.trendData.length - 1]?.value ?? 0);
 const firstValue = computed(() => props.trendData[0]?.value ?? 0);

--- a/app/components/prediction/PriceTrendChart.vue
+++ b/app/components/prediction/PriceTrendChart.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed } from 'vue';
+import { computed, onBeforeUnmount, onMounted, ref } from 'vue';
 import {
 	CategoryScale,
 	Chart as ChartJS,
@@ -19,8 +19,28 @@ import { formatCurrencyTick, normalizePrice, type PredictionTheme, type TrendPoi
 const props = defineProps<{
 	data: TrendPoint[];
 	theme: PredictionTheme;
-	isMobile: boolean;
 }>();
+
+const isMobile = ref(false);
+
+function updateViewport() {
+	if (!import.meta.client) {
+		return;
+	}
+
+	isMobile.value = window.innerWidth < 900;
+}
+
+onMounted(() => {
+	updateViewport();
+	window.addEventListener('resize', updateViewport);
+});
+
+onBeforeUnmount(() => {
+	if (import.meta.client) {
+		window.removeEventListener('resize', updateViewport);
+	}
+});
 
 ChartJS.register(
 	CategoryScale,
@@ -37,8 +57,8 @@ const chartData = computed<ChartData<'line'>>(() => ({
 		{
 			data: props.data.map((entry) => entry.value),
 			fill: true,
-			tension: 0.32,
-			borderWidth: 2.75,
+			tension: 0.4,
+			borderWidth: 3,
 			pointRadius: 0,
 			pointHoverRadius: 4,
 			pointHoverBorderWidth: 2,
@@ -100,8 +120,8 @@ const chartOptions = computed<ChartOptions<'line'>>(() => ({
 				maxRotation: 0,
 				autoSkipPadding: 18,
 				font: {
-					family: '"Avenir Next", "Segoe UI", sans-serif',
-					size: props.isMobile ? 11 : 12
+					family: "'DM Sans', 'Segoe UI', sans-serif",
+					size: isMobile.value ? 11 : 12
 				}
 			}
 		},
@@ -115,8 +135,8 @@ const chartOptions = computed<ChartOptions<'line'>>(() => ({
 				color: props.theme.textMuted,
 				callback: (value) => formatCurrencyTick(Number(value)),
 				font: {
-					family: '"Avenir Next", "Segoe UI", sans-serif',
-					size: props.isMobile ? 11 : 12
+					family: "'DM Sans', 'Segoe UI', sans-serif",
+					size: isMobile.value ? 11 : 12
 				}
 			}
 		}

--- a/bun.lock
+++ b/bun.lock
@@ -10,9 +10,7 @@
         "vue-chartjs": "^5.3.2",
       },
       "devDependencies": {
-        "@element-plus/nuxt": "^1.1.4",
         "@nuxt/eslint": "1.11.0",
-        "element-plus": "^2.11.7",
         "eslint": "9.39.1",
         "nuxt": "^4.2.1",
         "prettier": "3.7.4",
@@ -83,15 +81,9 @@
 
     "@cloudflare/kv-asset-handler": ["@cloudflare/kv-asset-handler@0.4.0", "", { "dependencies": { "mime": "^3.0.0" } }, "sha512-+tv3z+SPp+gqTIcImN9o0hqE9xyfQjI1XD9pL6NuKjua9B1y7mNYv0S9cP+QEbA4ppVgGZEmKOvHX5G5Ei1CVA=="],
 
-    "@ctrl/tinycolor": ["@ctrl/tinycolor@4.2.0", "", {}, "sha512-kzyuwOAQnXJNLS9PSyrk0CWk35nWJW/zl/6KvnTBMFK65gm7U1/Z5BqjxeapjZCIhQcM/DsrEmcbRwDyXyXK4A=="],
-
     "@dxup/nuxt": ["@dxup/nuxt@0.2.1", "", { "dependencies": { "@dxup/unimport": "^0.1.1", "@nuxt/kit": "^4.2.0", "chokidar": "^4.0.3", "pathe": "^2.0.3", "tinyglobby": "^0.2.15" } }, "sha512-0RLwkep6ftN3nd4Pfcgwrz8L5D2p5Tf8DKs3pr91TYO22N8loa9y8oPLQnJDqvrT0FBMEiCyPA7C8AMl7THPPg=="],
 
     "@dxup/unimport": ["@dxup/unimport@0.1.1", "", {}, "sha512-DLrjNapztDceDgvVL28D/8CyXIVbhIRGvYl+QGeiclLG6UZjG0a2q4+bGBeTfbt++wF0F7lYaI/MipPmXSNgnA=="],
-
-    "@element-plus/icons-vue": ["@element-plus/icons-vue@2.3.2", "", { "peerDependencies": { "vue": "^3.2.0" } }, "sha512-OzIuTaIfC8QXEPmJvB4Y4kw34rSXdCJzxcD1kFStBvr8bK6X1zQAYDo0CNMjojnfTqRQCJ0I7prlErcoRiET2A=="],
-
-    "@element-plus/nuxt": ["@element-plus/nuxt@1.1.5", "", { "dependencies": { "@nuxt/kit": "^4.2.2", "magic-string": "^0.30.21", "unplugin": "^3.0.0" }, "peerDependencies": { "@element-plus/icons-vue": ">=0.2.6", "element-plus": ">=2" } }, "sha512-ghmwnxAzA8B7OhRm/9ahDHzMCQVk+/urAbQZqUevU7stgCofSNsZ4by6XzwUkPQIIuKQQwgZ7gF6614+KH8ZNw=="],
 
     "@emnapi/core": ["@emnapi/core@1.7.0", "", { "dependencies": { "@emnapi/wasi-threads": "1.1.0", "tslib": "^2.4.0" } }, "sha512-pJdKGq/1iquWYtv1RRSljZklxHCOCAJFJrImO5ZLKPJVJlVUcs8yFwNQlqS0Lo8xT1VAXXTCZocF9n26FWEKsw=="],
 
@@ -177,12 +169,6 @@
 
     "@eslint/plugin-kit": ["@eslint/plugin-kit@0.4.1", "", { "dependencies": { "@eslint/core": "^0.17.0", "levn": "^0.4.1" } }, "sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA=="],
 
-    "@floating-ui/core": ["@floating-ui/core@1.7.5", "", { "dependencies": { "@floating-ui/utils": "^0.2.11" } }, "sha512-1Ih4WTWyw0+lKyFMcBHGbb5U5FtuHJuujoyyr5zTaWS5EYMeT6Jb2AuDeftsCsEuchO+mM2ij5+q9crhydzLhQ=="],
-
-    "@floating-ui/dom": ["@floating-ui/dom@1.7.6", "", { "dependencies": { "@floating-ui/core": "^1.7.5", "@floating-ui/utils": "^0.2.11" } }, "sha512-9gZSAI5XM36880PPMm//9dfiEngYoC6Am2izES1FF406YFsjvyBMmeJ2g4SAju3xWwtuynNRFL2s9hgxpLI5SQ=="],
-
-    "@floating-ui/utils": ["@floating-ui/utils@0.2.11", "", {}, "sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg=="],
-
     "@humanfs/core": ["@humanfs/core@0.19.1", "", {}, "sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA=="],
 
     "@humanfs/node": ["@humanfs/node@0.16.7", "", { "dependencies": { "@humanfs/core": "^0.19.1", "@humanwhocodes/retry": "^0.4.0" } }, "sha512-/zUx+yOsIrG4Y43Eh2peDeKCxlRt/gET6aHfaKpuq267qXdYDFViVHfMaLyygZOnl0kGWxFIgsBy8QFuTLUXEQ=="],
@@ -241,7 +227,7 @@
 
     "@nuxt/eslint-plugin": ["@nuxt/eslint-plugin@1.11.0", "", { "dependencies": { "@typescript-eslint/types": "^8.48.0", "@typescript-eslint/utils": "^8.48.0" }, "peerDependencies": { "eslint": "^9.0.0" } }, "sha512-kTNwHJjdr5qW90ww4ct8kFKdWEVb/8X4KdkDJAmRTRqLRfkfTQDOKDfpQa62fRnsuRopMEPjab3Bsya4YLbb9g=="],
 
-    "@nuxt/kit": ["@nuxt/kit@4.4.2", "", { "dependencies": { "c12": "^3.3.3", "consola": "^3.4.2", "defu": "^6.1.4", "destr": "^2.0.5", "errx": "^0.1.0", "exsolve": "^1.0.8", "ignore": "^7.0.5", "jiti": "^2.6.1", "klona": "^2.0.6", "mlly": "^1.8.1", "ohash": "^2.0.11", "pathe": "^2.0.3", "pkg-types": "^2.3.0", "rc9": "^3.0.0", "scule": "^1.3.0", "semver": "^7.7.4", "tinyglobby": "^0.2.15", "ufo": "^1.6.3", "unctx": "^2.5.0", "untyped": "^2.0.0" } }, "sha512-5+IPRNX2CjkBhuWUwz0hBuLqiaJPRoKzQ+SvcdrQDbAyE+VDeFt74VpSFr5/R0ujrK4b+XnSHUJWdS72w6hsog=="],
+    "@nuxt/kit": ["@nuxt/kit@4.2.1", "", { "dependencies": { "c12": "^3.3.1", "consola": "^3.4.2", "defu": "^6.1.4", "destr": "^2.0.5", "errx": "^0.1.0", "exsolve": "^1.0.7", "ignore": "^7.0.5", "jiti": "^2.6.1", "klona": "^2.0.6", "mlly": "^1.8.0", "ohash": "^2.0.11", "pathe": "^2.0.3", "pkg-types": "^2.3.0", "rc9": "^2.1.2", "scule": "^1.3.0", "semver": "^7.7.3", "tinyglobby": "^0.2.15", "ufo": "^1.6.1", "unctx": "^2.4.1", "untyped": "^2.0.0" } }, "sha512-lLt8KLHyl7IClc3RqRpRikz15eCfTRlAWL9leVzPyg5N87FfKE/7EWgWvpiL/z4Tf3dQCIqQb88TmHE0JTIDvA=="],
 
     "@nuxt/nitro-server": ["@nuxt/nitro-server@4.2.1", "", { "dependencies": { "@nuxt/devalue": "^2.0.2", "@nuxt/kit": "4.2.1", "@unhead/vue": "^2.0.19", "@vue/shared": "^3.5.23", "consola": "^3.4.2", "defu": "^6.1.4", "destr": "^2.0.5", "devalue": "^5.4.2", "errx": "^0.1.0", "escape-string-regexp": "^5.0.0", "exsolve": "^1.0.7", "h3": "^1.15.4", "impound": "^1.0.0", "klona": "^2.0.6", "mocked-exports": "^0.1.1", "nitropack": "^2.12.9", "pathe": "^2.0.3", "pkg-types": "^2.3.0", "radix3": "^1.1.2", "std-env": "^3.10.0", "ufo": "^1.6.1", "unctx": "^2.4.1", "unstorage": "^1.17.2", "vue": "^3.5.23", "vue-bundle-renderer": "^2.2.0", "vue-devtools-stub": "^0.1.0" }, "peerDependencies": { "nuxt": "^4.2.1" } }, "sha512-P6zGvKgbjwDO28A4QnRuhL0riNSxcw317nGSYfP9Z+V+GyCNVc9yCcAEuzRIvm+dv4PB6VC708my8Jq30VM9Ow=="],
 
@@ -377,8 +363,6 @@
 
     "@polka/url": ["@polka/url@1.0.0-next.29", "", {}, "sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww=="],
 
-    "@popperjs/core": ["@sxzz/popperjs-es@2.11.8", "", {}, "sha512-wOwESXvvED3S8xBmcPWHs2dUuzrE4XiZeFu7e1hROIJkm02a49N120pmOXxY33sBb6hArItm5W5tcg1cBtV+HQ=="],
-
     "@poppinss/colors": ["@poppinss/colors@4.1.5", "", { "dependencies": { "kleur": "^4.1.5" } }, "sha512-FvdDqtcRCtz6hThExcFOgW0cWX+xwSMWcRuQe5ZEb2m7cVQOAVZOIMt+/v9RxGiD9/OY16qJBXK4CVKWAPalBw=="],
 
     "@poppinss/dumper": ["@poppinss/dumper@0.6.5", "", { "dependencies": { "@poppinss/colors": "^4.1.5", "@sindresorhus/is": "^7.0.2", "supports-color": "^10.0.0" } }, "sha512-NBdYIb90J7LfOI32dOewKI1r7wnkiH6m920puQ3qHUeZkxNkQiFnXVWoE6YtFSv6QOiPPf7ys6i+HWWecDz7sw=="],
@@ -463,15 +447,9 @@
 
     "@types/json-schema": ["@types/json-schema@7.0.15", "", {}, "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA=="],
 
-    "@types/lodash": ["@types/lodash@4.17.24", "", {}, "sha512-gIW7lQLZbue7lRSWEFql49QJJWThrTFFeIMJdp3eH4tKoxm1OvEPg02rm4wCCSHS0cL3/Fizimb35b7k8atwsQ=="],
-
-    "@types/lodash-es": ["@types/lodash-es@4.17.12", "", { "dependencies": { "@types/lodash": "*" } }, "sha512-0NgftHUcV4v34VhXm8QBSftKVXtbkBG3ViCjs6+eJ5a6y6Mi/jiFGPc1sC7QK+9BFhWrURE3EOggmWaSxL9OzQ=="],
-
     "@types/parse-path": ["@types/parse-path@7.0.3", "", {}, "sha512-LriObC2+KYZD3FzCrgWGv/qufdUy4eXrxcLgQMfYXgPbLIecKIsVBaQgUPmxSSLcjmYbDTQbMgr6qr6l/eb7Bg=="],
 
     "@types/resolve": ["@types/resolve@1.20.2", "", {}, "sha512-60BCwRFOZCQhDncwQdxxeOEEkbc5dIMccYLwbxsS4TUNeVECQ/pBJ0j09mrHOl/JJvpRPGwO9SvE4nR2Nb/a4Q=="],
-
-    "@types/web-bluetooth": ["@types/web-bluetooth@0.0.20", "", {}, "sha512-g9gZnnXVq7gM7v3tJCWV/qw7w+KeOlSHAhgF9RytFyifW6AF61hdT2ucrYhPq9hLs5JIryeupHV3qGk95dH9ow=="],
 
     "@typescript-eslint/eslint-plugin": ["@typescript-eslint/eslint-plugin@8.48.0", "", { "dependencies": { "@eslint-community/regexpp": "^4.10.0", "@typescript-eslint/scope-manager": "8.48.0", "@typescript-eslint/type-utils": "8.48.0", "@typescript-eslint/utils": "8.48.0", "@typescript-eslint/visitor-keys": "8.48.0", "graphemer": "^1.4.0", "ignore": "^7.0.0", "natural-compare": "^1.4.0", "ts-api-utils": "^2.1.0" }, "peerDependencies": { "@typescript-eslint/parser": "^8.48.0", "eslint": "^8.57.0 || ^9.0.0", "typescript": ">=4.8.4 <6.0.0" } }, "sha512-XxXP5tL1txl13YFtrECECQYeZjBZad4fyd3cFV4a19LkAY/bIp9fev3US4S5fDVV2JaYFiKAZ/GRTOLer+mbyQ=="],
 
@@ -579,12 +557,6 @@
 
     "@vue/shared": ["@vue/shared@3.5.25", "", {}, "sha512-AbOPdQQnAnzs58H2FrrDxYj/TJfmeS2jdfEEhgiKINy+bnOANmVizIEgq1r+C5zsbs6l1CCQxtcj71rwNQ4jWg=="],
 
-    "@vueuse/core": ["@vueuse/core@12.0.0", "", { "dependencies": { "@types/web-bluetooth": "^0.0.20", "@vueuse/metadata": "12.0.0", "@vueuse/shared": "12.0.0", "vue": "^3.5.13" } }, "sha512-C12RukhXiJCbx4MGhjmd/gH52TjJsc3G0E0kQj/kb19H3Nt6n1CA4DRWuTdWWcaFRdlTe0npWDS942mvacvNBw=="],
-
-    "@vueuse/metadata": ["@vueuse/metadata@12.0.0", "", {}, "sha512-Yzimd1D3sjxTDOlF05HekU5aSGdKjxhuhRFHA7gDWLn57PRbBIh+SF5NmjhJ0WRgF3my7T8LBucyxdFJjIfRJQ=="],
-
-    "@vueuse/shared": ["@vueuse/shared@12.0.0", "", { "dependencies": { "vue": "^3.5.13" } }, "sha512-3i6qtcq2PIio5i/vVYidkkcgvmTjCqrf26u+Fd4LhnbBmIT6FN8y6q/GJERp8lfcB9zVEfjdV0Br0443qZuJpw=="],
-
     "abbrev": ["abbrev@3.0.1", "", {}, "sha512-AO2ac6pjRB3SJmGJo+v5/aK6Omggp6fsLrs6wN9bd35ulu4cCwaAU9+7ZhXjeqHVkaHThLuzH0nZr0YpCDhygg=="],
 
     "abort-controller": ["abort-controller@3.0.0", "", { "dependencies": { "event-target-shim": "^5.0.0" } }, "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg=="],
@@ -624,8 +596,6 @@
     "async": ["async@3.2.6", "", {}, "sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA=="],
 
     "async-sema": ["async-sema@3.1.1", "", {}, "sha512-tLRNUXati5MFePdAk8dw7Qt7DpxPB60ofAgn8WRhW6a2rcimZnYBP9oxHiv0OHy+Wz7kPMG+t4LGdt31+4EmGg=="],
-
-    "async-validator": ["async-validator@4.2.5", "", {}, "sha512-7HhHjtERjqlNbZtqNqy2rckN/SpOOlmDliet+lP7k+eKZEjPk3DgyeU9lIXLdeLz0uBbbVp+9Qdow9wJWgwwfg=="],
 
     "autoprefixer": ["autoprefixer@10.4.21", "", { "dependencies": { "browserslist": "^4.24.4", "caniuse-lite": "^1.0.30001702", "fraction.js": "^4.3.7", "normalize-range": "^0.1.2", "picocolors": "^1.1.1", "postcss-value-parser": "^4.2.0" }, "peerDependencies": { "postcss": "^8.1.0" }, "bin": "bin/autoprefixer" }, "sha512-O+A6LWV5LDHSJD3LjHYoNi4VLsj/Whi7k6zG12xTYaU4cQ8oxQGckXNX8cRHK5yOZ/ppVHe0ZBXGzSV9jXdVbQ=="],
 
@@ -808,8 +778,6 @@
     "ee-first": ["ee-first@1.1.1", "", {}, "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow=="],
 
     "electron-to-chromium": ["electron-to-chromium@1.5.244", "", {}, "sha512-OszpBN7xZX4vWMPJwB9illkN/znA8M36GQqQxi6MNy9axWxhOfJyZZJtSLQCpEFLHP2xK33BiWx9aIuIEXVCcw=="],
-
-    "element-plus": ["element-plus@2.13.7", "", { "dependencies": { "@ctrl/tinycolor": "^4.2.0", "@element-plus/icons-vue": "^2.3.2", "@floating-ui/dom": "^1.0.1", "@popperjs/core": "npm:@sxzz/popperjs-es@^2.11.7", "@types/lodash": "^4.17.20", "@types/lodash-es": "^4.17.12", "@vueuse/core": "12.0.0", "async-validator": "^4.2.5", "dayjs": "^1.11.19", "lodash": "^4.17.23", "lodash-es": "^4.17.23", "lodash-unified": "^1.0.3", "memoize-one": "^6.0.0", "normalize-wheel-es": "^1.2.0", "vue-component-type-helpers": "^3.2.4" }, "peerDependencies": { "vue": "^3.3.0" } }, "sha512-XdHATFZOyzVFL1DaHQ90IOJQSg9UnSAV+bhDW+YB5UoZ0Hxs50mwqjqfwXkuwpSag+VXXizVcErBR6Movo5daw=="],
 
     "emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
 
@@ -1089,11 +1057,7 @@
 
     "locate-path": ["locate-path@8.0.0", "", { "dependencies": { "p-locate": "^6.0.0" } }, "sha512-XT9ewWAC43tiAV7xDAPflMkG0qOPn2QjHqlgX8FOqmWa/rxnyYDulF9T0F7tRy1u+TVTmK/M//6VIOye+2zDXg=="],
 
-    "lodash": ["lodash@4.18.1", "", {}, "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q=="],
-
-    "lodash-es": ["lodash-es@4.18.1", "", {}, "sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A=="],
-
-    "lodash-unified": ["lodash-unified@1.0.3", "", { "peerDependencies": { "@types/lodash-es": "*", "lodash": "*", "lodash-es": "*" } }, "sha512-WK9qSozxXOD7ZJQlpSqOT+om2ZfcT4yO+03FuzAHD0wF6S0l0090LRPDx3vhTTLZ8cFKpBn+IOcVXK6qOcIlfQ=="],
+    "lodash": ["lodash@4.17.21", "", {}, "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="],
 
     "lodash.defaults": ["lodash.defaults@4.2.0", "", {}, "sha512-qjxPLHd3r5DnsdGacqOMU6pb/avJzdh9tFX2ymgoZE27BmjXrNy/y4LoaiTeAb+O3gL8AfpJGtqfX/ae2leYYQ=="],
 
@@ -1116,8 +1080,6 @@
     "magicast": ["magicast@0.5.1", "", { "dependencies": { "@babel/parser": "^7.28.5", "@babel/types": "^7.28.5", "source-map-js": "^1.2.1" } }, "sha512-xrHS24IxaLrvuo613F719wvOIv9xPHFWQHuvGUBmPnCA/3MQxKI3b+r7n1jAoDHmsbC5bRhTZYR77invLAxVnw=="],
 
     "mdn-data": ["mdn-data@2.12.2", "", {}, "sha512-IEn+pegP1aManZuckezWCO+XZQDplx1366JoVhTpMpBB1sPey/SbveZQUosKiKiGYjg1wH4pMlNgXbCiYgihQA=="],
-
-    "memoize-one": ["memoize-one@6.0.0", "", {}, "sha512-rkpe71W0N0c0Xz6QD0eJETuWAJGnJ9afsl1srmwPrI+yBCkge5EycXXbYRyvL29zZVUWQCY7InPRCv3GDXuZNw=="],
 
     "merge-stream": ["merge-stream@2.0.0", "", {}, "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w=="],
 
@@ -1180,8 +1142,6 @@
     "normalize-path": ["normalize-path@3.0.0", "", {}, "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA=="],
 
     "normalize-range": ["normalize-range@0.1.2", "", {}, "sha512-bdok/XvKII3nUpklnV6P2hxtMNrCboOjAcyBuQnWEhO665FwrSNRxU+AqpsyvO6LgGYPspN+lu5CLtw4jPRKNA=="],
-
-    "normalize-wheel-es": ["normalize-wheel-es@1.2.0", "", {}, "sha512-Wj7+EJQ8mSuXr2iWfnujrimU35R2W4FAErEyTmJoJ7ucwTn2hOUSsRehMb5RSYkxXGTM7Y9QpvPmp++w5ftoJw=="],
 
     "npm-run-path": ["npm-run-path@5.3.0", "", { "dependencies": { "path-key": "^4.0.0" } }, "sha512-ppwTtiJZq0O/ai0z7yfudtBpWIoxM8yE6nHi1X47eFR2EWORqfbu6CnPlNsjeN683eT0qG6H/Pyf9fCcvjnnnQ=="],
 
@@ -1347,7 +1307,7 @@
 
     "range-parser": ["range-parser@1.2.1", "", {}, "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg=="],
 
-    "rc9": ["rc9@3.0.1", "", { "dependencies": { "defu": "^6.1.6", "destr": "^2.0.5" } }, "sha512-gMDyleLWVE+i6Sgtc0QbbY6pEKqYs97NGi6isHQPqYlLemPoO8dxQ3uGi0f4NiP98c+jMW6cG1Kx9dDwfvqARQ=="],
+    "rc9": ["rc9@2.1.2", "", { "dependencies": { "defu": "^6.1.4", "destr": "^2.0.3" } }, "sha512-btXCnMmRIBINM2LDZoEmOogIZU7Qe7zn4BpomSKZ/ykbLObuBdvG+mFq11DL6fjH1DRwHhrlgtYWG96bJiC7Cg=="],
 
     "readable-stream": ["readable-stream@4.7.0", "", { "dependencies": { "abort-controller": "^3.0.0", "buffer": "^6.0.3", "events": "^3.3.0", "process": "^0.11.10", "string_decoder": "^1.3.0" } }, "sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg=="],
 
@@ -1543,7 +1503,7 @@
 
     "unimport": ["unimport@5.5.0", "", { "dependencies": { "acorn": "^8.15.0", "escape-string-regexp": "^5.0.0", "estree-walker": "^3.0.3", "local-pkg": "^1.1.2", "magic-string": "^0.30.19", "mlly": "^1.8.0", "pathe": "^2.0.3", "picomatch": "^4.0.3", "pkg-types": "^2.3.0", "scule": "^1.3.0", "strip-literal": "^3.1.0", "tinyglobby": "^0.2.15", "unplugin": "^2.3.10", "unplugin-utils": "^0.3.0" } }, "sha512-/JpWMG9s1nBSlXJAQ8EREFTFy3oy6USFd8T6AoBaw1q2GGcF4R9yp3ofg32UODZlYEO5VD0EWE1RpI9XDWyPYg=="],
 
-    "unplugin": ["unplugin@3.0.0", "", { "dependencies": { "@jridgewell/remapping": "^2.3.5", "picomatch": "^4.0.3", "webpack-virtual-modules": "^0.6.2" } }, "sha512-0Mqk3AT2TZCXWKdcoaufeXNukv2mTrEZExeXlHIOZXdqYoHHr4n51pymnwV8x2BOVxwXbK2HLlI7usrqMpycdg=="],
+    "unplugin": ["unplugin@2.3.10", "", { "dependencies": { "@jridgewell/remapping": "^2.3.5", "acorn": "^8.15.0", "picomatch": "^4.0.3", "webpack-virtual-modules": "^0.6.2" } }, "sha512-6NCPkv1ClwH+/BGE9QeoTIl09nuiAt0gS28nn1PvYXsGKRwM2TCbFA2QiilmehPDTXIe684k4rZI1yl3A1PCUw=="],
 
     "unplugin-utils": ["unplugin-utils@0.3.1", "", { "dependencies": { "pathe": "^2.0.3", "picomatch": "^4.0.3" } }, "sha512-5lWVjgi6vuHhJ526bI4nlCOmkCIF3nnfXkCMDeMJrtdvxTs6ZFCM8oNufGTsDbKv/tJ/xj8RpvXjRuPBZJuJog=="],
 
@@ -1588,8 +1548,6 @@
     "vue-bundle-renderer": ["vue-bundle-renderer@2.2.0", "", { "dependencies": { "ufo": "^1.6.1" } }, "sha512-sz/0WEdYH1KfaOm0XaBmRZOWgYTEvUDt6yPYaUzl4E52qzgWLlknaPPTTZmp6benaPTlQAI/hN1x3tAzZygycg=="],
 
     "vue-chartjs": ["vue-chartjs@5.3.3", "", { "peerDependencies": { "chart.js": "^4.1.1", "vue": "^3.0.0-0 || ^2.7.0" } }, "sha512-jqxtL8KZ6YJ5NTv6XzrzLS7osyegOi28UGNZW0h9OkDL7Sh1396ht4Dorh04aKrl2LiSalQ84WtqiG0RIJb0tA=="],
-
-    "vue-component-type-helpers": ["vue-component-type-helpers@3.2.6", "", {}, "sha512-O02tnvIfOQVmnvoWwuSydwRoHjZVt8UEBR+2p4rT35p8GAy5VTlWP8o5qXfJR/GWCN0nVZoYWsVUvx2jwgdBmQ=="],
 
     "vue-devtools-stub": ["vue-devtools-stub@0.1.0", "", {}, "sha512-RutnB7X8c5hjq39NceArgXg28WZtZpGc3+J16ljMiYnFhKvd8hITxSWQSQ5bvldxMDU6gG5mkxl1MTQLXckVSQ=="],
 
@@ -1669,37 +1627,13 @@
 
     "@mapbox/node-pre-gyp/detect-libc": ["detect-libc@2.1.2", "", {}, "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ=="],
 
-    "@nuxt/devtools/@nuxt/kit": ["@nuxt/kit@4.2.1", "", { "dependencies": { "c12": "^3.3.1", "consola": "^3.4.2", "defu": "^6.1.4", "destr": "^2.0.5", "errx": "^0.1.0", "exsolve": "^1.0.7", "ignore": "^7.0.5", "jiti": "^2.6.1", "klona": "^2.0.6", "mlly": "^1.8.0", "ohash": "^2.0.11", "pathe": "^2.0.3", "pkg-types": "^2.3.0", "rc9": "^2.1.2", "scule": "^1.3.0", "semver": "^7.7.3", "tinyglobby": "^0.2.15", "ufo": "^1.6.1", "unctx": "^2.4.1", "untyped": "^2.0.0" } }, "sha512-lLt8KLHyl7IClc3RqRpRikz15eCfTRlAWL9leVzPyg5N87FfKE/7EWgWvpiL/z4Tf3dQCIqQb88TmHE0JTIDvA=="],
-
     "@nuxt/devtools/which": ["which@5.0.0", "", { "dependencies": { "isexe": "^3.1.1" }, "bin": { "node-which": "bin/which.js" } }, "sha512-JEdGzHwwkrbWoGOlIHqQ5gtprKGOenpDHpxE9zVR1bWbOtYRyPPHMe9FaP6x61CmNaTThSkb0DAJte5jD+DmzQ=="],
 
-    "@nuxt/devtools-kit/@nuxt/kit": ["@nuxt/kit@4.2.1", "", { "dependencies": { "c12": "^3.3.1", "consola": "^3.4.2", "defu": "^6.1.4", "destr": "^2.0.5", "errx": "^0.1.0", "exsolve": "^1.0.7", "ignore": "^7.0.5", "jiti": "^2.6.1", "klona": "^2.0.6", "mlly": "^1.8.0", "ohash": "^2.0.11", "pathe": "^2.0.3", "pkg-types": "^2.3.0", "rc9": "^2.1.2", "scule": "^1.3.0", "semver": "^7.7.3", "tinyglobby": "^0.2.15", "ufo": "^1.6.1", "unctx": "^2.4.1", "untyped": "^2.0.0" } }, "sha512-lLt8KLHyl7IClc3RqRpRikz15eCfTRlAWL9leVzPyg5N87FfKE/7EWgWvpiL/z4Tf3dQCIqQb88TmHE0JTIDvA=="],
-
-    "@nuxt/eslint/@nuxt/kit": ["@nuxt/kit@4.2.1", "", { "dependencies": { "c12": "^3.3.1", "consola": "^3.4.2", "defu": "^6.1.4", "destr": "^2.0.5", "errx": "^0.1.0", "exsolve": "^1.0.7", "ignore": "^7.0.5", "jiti": "^2.6.1", "klona": "^2.0.6", "mlly": "^1.8.0", "ohash": "^2.0.11", "pathe": "^2.0.3", "pkg-types": "^2.3.0", "rc9": "^2.1.2", "scule": "^1.3.0", "semver": "^7.7.3", "tinyglobby": "^0.2.15", "ufo": "^1.6.1", "unctx": "^2.4.1", "untyped": "^2.0.0" } }, "sha512-lLt8KLHyl7IClc3RqRpRikz15eCfTRlAWL9leVzPyg5N87FfKE/7EWgWvpiL/z4Tf3dQCIqQb88TmHE0JTIDvA=="],
-
-    "@nuxt/kit/c12": ["c12@3.3.4", "", { "dependencies": { "chokidar": "^5.0.0", "confbox": "^0.2.4", "defu": "^6.1.6", "dotenv": "^17.3.1", "exsolve": "^1.0.8", "giget": "^3.2.0", "jiti": "^2.6.1", "ohash": "^2.0.11", "pathe": "^2.0.3", "perfect-debounce": "^2.1.0", "pkg-types": "^2.3.0", "rc9": "^3.0.1" }, "peerDependencies": { "magicast": "*" }, "optionalPeers": ["magicast"] }, "sha512-cM0ApFQSBXuourJejzwv/AuPRvAxordTyParRVcHjjtXirtkzM0uK2L9TTn9s0cXZbG7E55jCivRQzoxYmRAlA=="],
-
-    "@nuxt/kit/exsolve": ["exsolve@1.0.8", "", {}, "sha512-LmDxfWXwcTArk8fUEnOfSZpHOJ6zOMUJKOtFLFqJLoKJetuQG874Uc7/Kki7zFLzYybmZhp1M7+98pfMqeX8yA=="],
-
     "@nuxt/kit/ignore": ["ignore@7.0.5", "", {}, "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg=="],
-
-    "@nuxt/kit/mlly": ["mlly@1.8.2", "", { "dependencies": { "acorn": "^8.16.0", "pathe": "^2.0.3", "pkg-types": "^1.3.1", "ufo": "^1.6.3" } }, "sha512-d+ObxMQFmbt10sretNDytwt85VrbkhhUA/JBGm1MPaWJ65Cl4wOgLaB1NYvJSZ0Ef03MMEU/0xpPMXUIQ29UfA=="],
-
-    "@nuxt/kit/semver": ["semver@7.7.4", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA=="],
-
-    "@nuxt/kit/ufo": ["ufo@1.6.3", "", {}, "sha512-yDJTmhydvl5lJzBmy/hyOAA0d+aqCBuwl818haVdYCRrWV84o7YyeVm4QlVHStqNrrJSTb6jKuFAVqAFsr+K3Q=="],
-
-    "@nuxt/kit/unctx": ["unctx@2.5.0", "", { "dependencies": { "acorn": "^8.15.0", "estree-walker": "^3.0.3", "magic-string": "^0.30.21", "unplugin": "^2.3.11" } }, "sha512-p+Rz9x0R7X+CYDkT+Xg8/GhpcShTlU8n+cf9OtOEf7zEQsNcCZO1dPKNRDqvUTaq+P32PMMkxWHwfrxkqfqAYg=="],
-
-    "@nuxt/nitro-server/@nuxt/kit": ["@nuxt/kit@4.2.1", "", { "dependencies": { "c12": "^3.3.1", "consola": "^3.4.2", "defu": "^6.1.4", "destr": "^2.0.5", "errx": "^0.1.0", "exsolve": "^1.0.7", "ignore": "^7.0.5", "jiti": "^2.6.1", "klona": "^2.0.6", "mlly": "^1.8.0", "ohash": "^2.0.11", "pathe": "^2.0.3", "pkg-types": "^2.3.0", "rc9": "^2.1.2", "scule": "^1.3.0", "semver": "^7.7.3", "tinyglobby": "^0.2.15", "ufo": "^1.6.1", "unctx": "^2.4.1", "untyped": "^2.0.0" } }, "sha512-lLt8KLHyl7IClc3RqRpRikz15eCfTRlAWL9leVzPyg5N87FfKE/7EWgWvpiL/z4Tf3dQCIqQb88TmHE0JTIDvA=="],
 
     "@nuxt/nitro-server/escape-string-regexp": ["escape-string-regexp@5.0.0", "", {}, "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw=="],
 
     "@nuxt/telemetry/@nuxt/kit": ["@nuxt/kit@3.20.0", "", { "dependencies": { "c12": "^3.3.0", "consola": "^3.4.2", "defu": "^6.1.4", "destr": "^2.0.5", "errx": "^0.1.0", "exsolve": "^1.0.7", "ignore": "^7.0.5", "jiti": "^2.6.1", "klona": "^2.0.6", "knitwork": "^1.2.0", "mlly": "^1.8.0", "ohash": "^2.0.11", "pathe": "^2.0.3", "pkg-types": "^2.3.0", "rc9": "^2.1.2", "scule": "^1.3.0", "semver": "^7.7.3", "tinyglobby": "^0.2.15", "ufo": "^1.6.1", "unctx": "^2.4.1", "untyped": "^2.0.0" } }, "sha512-EoF1Gf0SPj9vxgAIcGEH+a4PRLC7Dwsy21K6f5+POzylT8DgssN8zL5pwXC+X7OcfzBrwYFh7mM7phvh7ubgeg=="],
-
-    "@nuxt/telemetry/rc9": ["rc9@2.1.2", "", { "dependencies": { "defu": "^6.1.4", "destr": "^2.0.3" } }, "sha512-btXCnMmRIBINM2LDZoEmOogIZU7Qe7zn4BpomSKZ/ykbLObuBdvG+mFq11DL6fjH1DRwHhrlgtYWG96bJiC7Cg=="],
-
-    "@nuxt/vite-builder/@nuxt/kit": ["@nuxt/kit@4.2.1", "", { "dependencies": { "c12": "^3.3.1", "consola": "^3.4.2", "defu": "^6.1.4", "destr": "^2.0.5", "errx": "^0.1.0", "exsolve": "^1.0.7", "ignore": "^7.0.5", "jiti": "^2.6.1", "klona": "^2.0.6", "mlly": "^1.8.0", "ohash": "^2.0.11", "pathe": "^2.0.3", "pkg-types": "^2.3.0", "rc9": "^2.1.2", "scule": "^1.3.0", "semver": "^7.7.3", "tinyglobby": "^0.2.15", "ufo": "^1.6.1", "unctx": "^2.4.1", "untyped": "^2.0.0" } }, "sha512-lLt8KLHyl7IClc3RqRpRikz15eCfTRlAWL9leVzPyg5N87FfKE/7EWgWvpiL/z4Tf3dQCIqQb88TmHE0JTIDvA=="],
 
     "@nuxt/vite-builder/esbuild": ["esbuild@0.25.12", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.25.12", "@esbuild/android-arm": "0.25.12", "@esbuild/android-arm64": "0.25.12", "@esbuild/android-x64": "0.25.12", "@esbuild/darwin-arm64": "0.25.12", "@esbuild/darwin-x64": "0.25.12", "@esbuild/freebsd-arm64": "0.25.12", "@esbuild/freebsd-x64": "0.25.12", "@esbuild/linux-arm": "0.25.12", "@esbuild/linux-arm64": "0.25.12", "@esbuild/linux-ia32": "0.25.12", "@esbuild/linux-loong64": "0.25.12", "@esbuild/linux-mips64el": "0.25.12", "@esbuild/linux-ppc64": "0.25.12", "@esbuild/linux-riscv64": "0.25.12", "@esbuild/linux-s390x": "0.25.12", "@esbuild/linux-x64": "0.25.12", "@esbuild/netbsd-arm64": "0.25.12", "@esbuild/netbsd-x64": "0.25.12", "@esbuild/openbsd-arm64": "0.25.12", "@esbuild/openbsd-x64": "0.25.12", "@esbuild/openharmony-arm64": "0.25.12", "@esbuild/sunos-x64": "0.25.12", "@esbuild/win32-arm64": "0.25.12", "@esbuild/win32-ia32": "0.25.12", "@esbuild/win32-x64": "0.25.12" }, "bin": "bin/esbuild" }, "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg=="],
 
@@ -1745,15 +1679,11 @@
 
     "archiver-utils/is-stream": ["is-stream@2.0.1", "", {}, "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg=="],
 
-    "archiver-utils/lodash": ["lodash@4.17.21", "", {}, "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="],
-
     "c12/chokidar": ["chokidar@4.0.3", "", { "dependencies": { "readdirp": "^4.0.1" } }, "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA=="],
 
     "c12/dotenv": ["dotenv@17.2.3", "", {}, "sha512-JVUnt+DUIzu87TABbhPmNfVdBDt18BLOWjMUFJMSi/Qqg7NTYtabbvSNJGOJ7afbRuv9D/lngizHtP7QyLQ+9w=="],
 
     "c12/magicast": ["magicast@0.3.5", "", { "dependencies": { "@babel/parser": "^7.25.4", "@babel/types": "^7.25.4", "source-map-js": "^1.2.0" } }, "sha512-L0WhttDl+2BOsybvEOLK7fW3UA0OQ0IQ2d6Zl2x/a6vVRs3bAY0ECOSHHeL5jD+SbOpOCUEi0y1DgHEn9Qn1AQ=="],
-
-    "c12/rc9": ["rc9@2.1.2", "", { "dependencies": { "defu": "^6.1.4", "destr": "^2.0.3" } }, "sha512-btXCnMmRIBINM2LDZoEmOogIZU7Qe7zn4BpomSKZ/ykbLObuBdvG+mFq11DL6fjH1DRwHhrlgtYWG96bJiC7Cg=="],
 
     "clean-regexp/escape-string-regexp": ["escape-string-regexp@1.0.5", "", {}, "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg=="],
 
@@ -1779,15 +1709,11 @@
 
     "h3/cookie-es": ["cookie-es@1.2.2", "", {}, "sha512-+W7VmiVINB+ywl1HGXJXmrqkOhpKrIiVZV6tQuV54ZyQC7MMuBt81Vc336GMLoHBq5hV/F9eXgt5Mnx0Rha5Fg=="],
 
-    "impound/unplugin": ["unplugin@2.3.10", "", { "dependencies": { "@jridgewell/remapping": "^2.3.5", "acorn": "^8.15.0", "picomatch": "^4.0.3", "webpack-virtual-modules": "^0.6.2" } }, "sha512-6NCPkv1ClwH+/BGE9QeoTIl09nuiAt0gS28nn1PvYXsGKRwM2TCbFA2QiilmehPDTXIe684k4rZI1yl3A1PCUw=="],
-
     "impound/unplugin-utils": ["unplugin-utils@0.2.5", "", { "dependencies": { "pathe": "^2.0.3", "picomatch": "^4.0.3" } }, "sha512-gwXJnPRewT4rT7sBi/IvxKTjsms7jX7QIDLOClApuZwR49SXbrB1z2NLUZ+vDHyqCj/n58OzRRqaW+B8OZi8vg=="],
 
     "lazystream/readable-stream": ["readable-stream@2.3.8", "", { "dependencies": { "core-util-is": "~1.0.0", "inherits": "~2.0.3", "isarray": "~1.0.0", "process-nextick-args": "~2.0.0", "safe-buffer": "~5.1.1", "string_decoder": "~1.1.1", "util-deprecate": "~1.0.1" } }, "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA=="],
 
     "listhen/pathe": ["pathe@1.1.2", "", {}, "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ=="],
-
-    "magic-regexp/unplugin": ["unplugin@2.3.10", "", { "dependencies": { "@jridgewell/remapping": "^2.3.5", "acorn": "^8.15.0", "picomatch": "^4.0.3", "webpack-virtual-modules": "^0.6.2" } }, "sha512-6NCPkv1ClwH+/BGE9QeoTIl09nuiAt0gS28nn1PvYXsGKRwM2TCbFA2QiilmehPDTXIe684k4rZI1yl3A1PCUw=="],
 
     "micromatch/picomatch": ["picomatch@2.3.1", "", {}, "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA=="],
 
@@ -1801,21 +1727,15 @@
 
     "npm-run-path/path-key": ["path-key@4.0.0", "", {}, "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ=="],
 
-    "nuxt/@nuxt/kit": ["@nuxt/kit@4.2.1", "", { "dependencies": { "c12": "^3.3.1", "consola": "^3.4.2", "defu": "^6.1.4", "destr": "^2.0.5", "errx": "^0.1.0", "exsolve": "^1.0.7", "ignore": "^7.0.5", "jiti": "^2.6.1", "klona": "^2.0.6", "mlly": "^1.8.0", "ohash": "^2.0.11", "pathe": "^2.0.3", "pkg-types": "^2.3.0", "rc9": "^2.1.2", "scule": "^1.3.0", "semver": "^7.7.3", "tinyglobby": "^0.2.15", "ufo": "^1.6.1", "unctx": "^2.4.1", "untyped": "^2.0.0" } }, "sha512-lLt8KLHyl7IClc3RqRpRikz15eCfTRlAWL9leVzPyg5N87FfKE/7EWgWvpiL/z4Tf3dQCIqQb88TmHE0JTIDvA=="],
-
     "nuxt/chokidar": ["chokidar@4.0.3", "", { "dependencies": { "readdirp": "^4.0.1" } }, "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA=="],
 
     "nuxt/escape-string-regexp": ["escape-string-regexp@5.0.0", "", {}, "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw=="],
 
     "nuxt/ignore": ["ignore@7.0.5", "", {}, "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg=="],
 
-    "nuxt/unplugin": ["unplugin@2.3.10", "", { "dependencies": { "@jridgewell/remapping": "^2.3.5", "acorn": "^8.15.0", "picomatch": "^4.0.3", "webpack-virtual-modules": "^0.6.2" } }, "sha512-6NCPkv1ClwH+/BGE9QeoTIl09nuiAt0gS28nn1PvYXsGKRwM2TCbFA2QiilmehPDTXIe684k4rZI1yl3A1PCUw=="],
-
     "postcss/nanoid": ["nanoid@3.3.11", "", { "bin": "bin/nanoid.cjs" }, "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w=="],
 
     "prompts/kleur": ["kleur@3.0.3", "", {}, "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w=="],
-
-    "rc9/defu": ["defu@6.1.7", "", {}, "sha512-7z22QmUWiQ/2d0KkdYmANbRUVABpZ9SNYyH5vx6PZ+nE5bcC0l7uFvEfHlyld/HcGBFTL536ClDt3DEcSlEJAQ=="],
 
     "readdir-glob/minimatch": ["minimatch@5.1.6", "", { "dependencies": { "brace-expansion": "^2.0.1" } }, "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g=="],
 
@@ -1825,21 +1745,13 @@
 
     "svgo/commander": ["commander@11.1.0", "", {}, "sha512-yPVavfyCcRhmorC7rWlkHn15b4wDVgVmBA7kV4QVBsF7kv/9TKJAbAXVTxvTnwP8HHKjRCJDClKbciiYS7p0DQ=="],
 
-    "unctx/unplugin": ["unplugin@2.3.10", "", { "dependencies": { "@jridgewell/remapping": "^2.3.5", "acorn": "^8.15.0", "picomatch": "^4.0.3", "webpack-virtual-modules": "^0.6.2" } }, "sha512-6NCPkv1ClwH+/BGE9QeoTIl09nuiAt0gS28nn1PvYXsGKRwM2TCbFA2QiilmehPDTXIe684k4rZI1yl3A1PCUw=="],
-
     "unimport/escape-string-regexp": ["escape-string-regexp@5.0.0", "", {}, "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw=="],
 
-    "unimport/unplugin": ["unplugin@2.3.10", "", { "dependencies": { "@jridgewell/remapping": "^2.3.5", "acorn": "^8.15.0", "picomatch": "^4.0.3", "webpack-virtual-modules": "^0.6.2" } }, "sha512-6NCPkv1ClwH+/BGE9QeoTIl09nuiAt0gS28nn1PvYXsGKRwM2TCbFA2QiilmehPDTXIe684k4rZI1yl3A1PCUw=="],
-
     "unplugin-vue-router/chokidar": ["chokidar@4.0.3", "", { "dependencies": { "readdirp": "^4.0.1" } }, "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA=="],
-
-    "unplugin-vue-router/unplugin": ["unplugin@2.3.10", "", { "dependencies": { "@jridgewell/remapping": "^2.3.5", "acorn": "^8.15.0", "picomatch": "^4.0.3", "webpack-virtual-modules": "^0.6.2" } }, "sha512-6NCPkv1ClwH+/BGE9QeoTIl09nuiAt0gS28nn1PvYXsGKRwM2TCbFA2QiilmehPDTXIe684k4rZI1yl3A1PCUw=="],
 
     "unstorage/chokidar": ["chokidar@4.0.3", "", { "dependencies": { "readdirp": "^4.0.1" } }, "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA=="],
 
     "untun/pathe": ["pathe@1.1.2", "", {}, "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ=="],
-
-    "unwasm/unplugin": ["unplugin@2.3.10", "", { "dependencies": { "@jridgewell/remapping": "^2.3.5", "acorn": "^8.15.0", "picomatch": "^4.0.3", "webpack-virtual-modules": "^0.6.2" } }, "sha512-6NCPkv1ClwH+/BGE9QeoTIl09nuiAt0gS28nn1PvYXsGKRwM2TCbFA2QiilmehPDTXIe684k4rZI1yl3A1PCUw=="],
 
     "vite/esbuild": ["esbuild@0.25.12", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.25.12", "@esbuild/android-arm": "0.25.12", "@esbuild/android-arm64": "0.25.12", "@esbuild/android-x64": "0.25.12", "@esbuild/darwin-arm64": "0.25.12", "@esbuild/darwin-x64": "0.25.12", "@esbuild/freebsd-arm64": "0.25.12", "@esbuild/freebsd-x64": "0.25.12", "@esbuild/linux-arm": "0.25.12", "@esbuild/linux-arm64": "0.25.12", "@esbuild/linux-ia32": "0.25.12", "@esbuild/linux-loong64": "0.25.12", "@esbuild/linux-mips64el": "0.25.12", "@esbuild/linux-ppc64": "0.25.12", "@esbuild/linux-riscv64": "0.25.12", "@esbuild/linux-s390x": "0.25.12", "@esbuild/linux-x64": "0.25.12", "@esbuild/netbsd-arm64": "0.25.12", "@esbuild/netbsd-x64": "0.25.12", "@esbuild/openbsd-arm64": "0.25.12", "@esbuild/openbsd-x64": "0.25.12", "@esbuild/openharmony-arm64": "0.25.12", "@esbuild/sunos-x64": "0.25.12", "@esbuild/win32-arm64": "0.25.12", "@esbuild/win32-ia32": "0.25.12", "@esbuild/win32-x64": "0.25.12" }, "bin": "bin/esbuild" }, "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg=="],
 
@@ -1855,8 +1767,6 @@
 
     "@dxup/nuxt/@nuxt/kit/ignore": ["ignore@7.0.5", "", {}, "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg=="],
 
-    "@dxup/nuxt/@nuxt/kit/rc9": ["rc9@2.1.2", "", { "dependencies": { "defu": "^6.1.4", "destr": "^2.0.3" } }, "sha512-btXCnMmRIBINM2LDZoEmOogIZU7Qe7zn4BpomSKZ/ykbLObuBdvG+mFq11DL6fjH1DRwHhrlgtYWG96bJiC7Cg=="],
-
     "@dxup/nuxt/chokidar/readdirp": ["readdirp@4.1.2", "", {}, "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg=="],
 
     "@eslint/config-inspector/chokidar/readdirp": ["readdirp@4.1.2", "", {}, "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg=="],
@@ -1867,47 +1777,9 @@
 
     "@isaacs/cliui/wrap-ansi/ansi-styles": ["ansi-styles@6.2.3", "", {}, "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg=="],
 
-    "@nuxt/devtools-kit/@nuxt/kit/ignore": ["ignore@7.0.5", "", {}, "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg=="],
-
-    "@nuxt/devtools-kit/@nuxt/kit/rc9": ["rc9@2.1.2", "", { "dependencies": { "defu": "^6.1.4", "destr": "^2.0.3" } }, "sha512-btXCnMmRIBINM2LDZoEmOogIZU7Qe7zn4BpomSKZ/ykbLObuBdvG+mFq11DL6fjH1DRwHhrlgtYWG96bJiC7Cg=="],
-
-    "@nuxt/devtools/@nuxt/kit/ignore": ["ignore@7.0.5", "", {}, "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg=="],
-
-    "@nuxt/devtools/@nuxt/kit/rc9": ["rc9@2.1.2", "", { "dependencies": { "defu": "^6.1.4", "destr": "^2.0.3" } }, "sha512-btXCnMmRIBINM2LDZoEmOogIZU7Qe7zn4BpomSKZ/ykbLObuBdvG+mFq11DL6fjH1DRwHhrlgtYWG96bJiC7Cg=="],
-
     "@nuxt/devtools/which/isexe": ["isexe@3.1.1", "", {}, "sha512-LpB/54B+/2J5hqQ7imZHfdU31OlgQqx7ZicVlkm9kzg9/w8GKLEcFfJl/t7DCEDueOyBAD6zCCwTO6Fzs0NoEQ=="],
 
-    "@nuxt/eslint/@nuxt/kit/ignore": ["ignore@7.0.5", "", {}, "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg=="],
-
-    "@nuxt/eslint/@nuxt/kit/rc9": ["rc9@2.1.2", "", { "dependencies": { "defu": "^6.1.4", "destr": "^2.0.3" } }, "sha512-btXCnMmRIBINM2LDZoEmOogIZU7Qe7zn4BpomSKZ/ykbLObuBdvG+mFq11DL6fjH1DRwHhrlgtYWG96bJiC7Cg=="],
-
-    "@nuxt/kit/c12/confbox": ["confbox@0.2.4", "", {}, "sha512-ysOGlgTFbN2/Y6Cg3Iye8YKulHw+R2fNXHrgSmXISQdMnomY6eNDprVdW9R5xBguEqI954+S6709UyiO7B+6OQ=="],
-
-    "@nuxt/kit/c12/defu": ["defu@6.1.7", "", {}, "sha512-7z22QmUWiQ/2d0KkdYmANbRUVABpZ9SNYyH5vx6PZ+nE5bcC0l7uFvEfHlyld/HcGBFTL536ClDt3DEcSlEJAQ=="],
-
-    "@nuxt/kit/c12/dotenv": ["dotenv@17.4.2", "", {}, "sha512-nI4U3TottKAcAD9LLud4Cb7b2QztQMUEfHbvhTH09bqXTxnSie8WnjPALV/WMCrJZ6UV/qHJ6L03OqO3LcdYZw=="],
-
-    "@nuxt/kit/c12/giget": ["giget@3.2.0", "", { "bin": { "giget": "dist/cli.mjs" } }, "sha512-GvHTWcykIR/fP8cj8dMpuMMkvaeJfPvYnhq0oW+chSeIr+ldX21ifU2Ms6KBoyKZQZmVaUAAhQ2EZ68KJF8a7A=="],
-
-    "@nuxt/kit/c12/perfect-debounce": ["perfect-debounce@2.1.0", "", {}, "sha512-LjgdTytVFXeUgtHZr9WYViYSM/g8MkcTPYDlPa3cDqMirHjKiSZPYd6DoL7pK8AJQr+uWkQvCjHNdiMqsrJs+g=="],
-
-    "@nuxt/kit/mlly/acorn": ["acorn@8.16.0", "", { "bin": { "acorn": "bin/acorn" } }, "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw=="],
-
-    "@nuxt/kit/mlly/pkg-types": ["pkg-types@1.3.1", "", { "dependencies": { "confbox": "^0.1.8", "mlly": "^1.7.4", "pathe": "^2.0.1" } }, "sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ=="],
-
-    "@nuxt/kit/unctx/acorn": ["acorn@8.16.0", "", { "bin": { "acorn": "bin/acorn" } }, "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw=="],
-
-    "@nuxt/kit/unctx/unplugin": ["unplugin@2.3.11", "", { "dependencies": { "@jridgewell/remapping": "^2.3.5", "acorn": "^8.15.0", "picomatch": "^4.0.3", "webpack-virtual-modules": "^0.6.2" } }, "sha512-5uKD0nqiYVzlmCRs01Fhs2BdkEgBS3SAVP6ndrBsuK42iC2+JHyxM05Rm9G8+5mkmRtzMZGY8Ct5+mliZxU/Ww=="],
-
-    "@nuxt/nitro-server/@nuxt/kit/ignore": ["ignore@7.0.5", "", {}, "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg=="],
-
-    "@nuxt/nitro-server/@nuxt/kit/rc9": ["rc9@2.1.2", "", { "dependencies": { "defu": "^6.1.4", "destr": "^2.0.3" } }, "sha512-btXCnMmRIBINM2LDZoEmOogIZU7Qe7zn4BpomSKZ/ykbLObuBdvG+mFq11DL6fjH1DRwHhrlgtYWG96bJiC7Cg=="],
-
     "@nuxt/telemetry/@nuxt/kit/ignore": ["ignore@7.0.5", "", {}, "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg=="],
-
-    "@nuxt/vite-builder/@nuxt/kit/ignore": ["ignore@7.0.5", "", {}, "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg=="],
-
-    "@nuxt/vite-builder/@nuxt/kit/rc9": ["rc9@2.1.2", "", { "dependencies": { "defu": "^6.1.4", "destr": "^2.0.3" } }, "sha512-btXCnMmRIBINM2LDZoEmOogIZU7Qe7zn4BpomSKZ/ykbLObuBdvG+mFq11DL6fjH1DRwHhrlgtYWG96bJiC7Cg=="],
 
     "@nuxt/vite-builder/esbuild/@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.25.12", "", { "os": "aix", "cpu": "ppc64" }, "sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA=="],
 
@@ -2055,8 +1927,6 @@
 
     "nitropack/esbuild/@esbuild/win32-x64": ["@esbuild/win32-x64@0.25.12", "", { "os": "win32", "cpu": "x64" }, "sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA=="],
 
-    "nuxt/@nuxt/kit/rc9": ["rc9@2.1.2", "", { "dependencies": { "defu": "^6.1.4", "destr": "^2.0.3" } }, "sha512-btXCnMmRIBINM2LDZoEmOogIZU7Qe7zn4BpomSKZ/ykbLObuBdvG+mFq11DL6fjH1DRwHhrlgtYWG96bJiC7Cg=="],
-
     "nuxt/chokidar/readdirp": ["readdirp@4.1.2", "", {}, "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg=="],
 
     "readdir-glob/minimatch/brace-expansion": ["brace-expansion@2.0.2", "", { "dependencies": { "balanced-match": "^1.0.0" } }, "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ=="],
@@ -2129,10 +1999,6 @@
 
     "vite/esbuild/@esbuild/win32-x64": ["@esbuild/win32-x64@0.25.12", "", { "os": "win32", "cpu": "x64" }, "sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA=="],
 
-    "@nuxt/kit/mlly/pkg-types/confbox": ["confbox@0.1.8", "", {}, "sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w=="],
-
-    "@nuxt/kit/mlly/pkg-types/mlly": ["mlly@1.8.0", "", { "dependencies": { "acorn": "^8.15.0", "pathe": "^2.0.3", "pkg-types": "^1.3.1", "ufo": "^1.6.1" } }, "sha512-l8D9ODSRWLe2KHJSifWGwBqpTZXIXTeo8mlKjY+E2HAakaTeNpqAyBZ8GSqLzHgw4XmHmC8whvpjJNMbFZN7/g=="],
-
     "@vue/language-core/@vue/compiler-dom/@vue/compiler-core/estree-walker": ["estree-walker@2.0.2", "", {}, "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w=="],
 
     "eslint/find-up/locate-path/p-locate": ["p-locate@5.0.0", "", { "dependencies": { "p-limit": "^3.0.2" } }, "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw=="],
@@ -2188,10 +2054,6 @@
     "vite-node/vite/esbuild/@esbuild/win32-ia32": ["@esbuild/win32-ia32@0.25.12", "", { "os": "win32", "cpu": "ia32" }, "sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ=="],
 
     "vite-node/vite/esbuild/@esbuild/win32-x64": ["@esbuild/win32-x64@0.25.12", "", { "os": "win32", "cpu": "x64" }, "sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA=="],
-
-    "@nuxt/kit/mlly/pkg-types/mlly/acorn": ["acorn@8.15.0", "", { "bin": "bin/acorn" }, "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg=="],
-
-    "@nuxt/kit/mlly/pkg-types/mlly/ufo": ["ufo@1.6.1", "", {}, "sha512-9a4/uxlTWJ4+a5i0ooc1rU7C7YOw3wT+UGqdeNNHWnOF9qcMBgLRS+4IYUqbczewFx4mLEig6gawh7X6mFlEkA=="],
 
     "eslint/find-up/locate-path/p-locate/p-limit": ["p-limit@3.1.0", "", { "dependencies": { "yocto-queue": "^0.1.0" } }, "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ=="],
 

--- a/locales/en.json
+++ b/locales/en.json
@@ -131,5 +131,9 @@
     "Type S1": "Type S1",
     "Type S2": "Type S2"
   },
-  "predicted_price": "Predicted Price"
+  "predicting": "Predicting…",
+  "predicted_price": "Predicted Price",
+  "awaiting": "Awaiting prediction",
+  "placeholder_title": "Run a scenario to generate a forecast",
+  "placeholder_body": "Choose a model, adjust the flat details, and submit the form to see the projected resale price and 12-month trend."
 }

--- a/locales/zh.json
+++ b/locales/zh.json
@@ -131,5 +131,9 @@
     "Type S1": "S1型",
     "Type S2": "S2型"
   },
-  "predicted_price": "预测价格"
+  "predicting": "预测中…",
+  "predicted_price": "预测价格",
+  "awaiting": "等待预测结果",
+  "placeholder_title": "提交一个情境后即可生成预测",
+  "placeholder_body": "选择模型并调整房屋资料后提交表单，即可查看预测转售价与过去12个月趋势。"
 }

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -4,6 +4,8 @@ export default defineNuxtConfig({
 	app: {
 		head: {
 			link: [
+				{ rel: 'preconnect', href: 'https://fonts.googleapis.com' },
+				{ rel: 'preconnect', href: 'https://fonts.gstatic.com', crossorigin: '' },
 				{
 					rel: 'stylesheet',
 					href: 'https://fonts.googleapis.com/css2?family=DM+Sans:ital,opsz,wght@0,9..40,400;0,9..40,500;0,9..40,600;0,9..40,700;0,9..40,800;1,9..40,400;1,9..40,500&family=Lora:ital,wght@0,400;0,500;0,600;0,700;1,400;1,500&display=swap'

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -1,7 +1,14 @@
 export default defineNuxtConfig({
 	css: ['~/assets/styles/prediction.css'],
-	modules: ['@nuxt/eslint', '@element-plus/nuxt'],
-	elementPlus: {
-		importStyle: 'css'
+	modules: ['@nuxt/eslint'],
+	app: {
+		head: {
+			link: [
+				{
+					rel: 'stylesheet',
+					href: 'https://fonts.googleapis.com/css2?family=DM+Sans:ital,opsz,wght@0,9..40,400;0,9..40,500;0,9..40,600;0,9..40,700;0,9..40,800;1,9..40,400;1,9..40,500&family=Lora:ital,wght@0,400;0,500;0,600;0,700;1,400;1,500&display=swap'
+				}
+			]
+		}
 	}
 });

--- a/package.json
+++ b/package.json
@@ -9,9 +9,7 @@
     	"lint:fix": "eslint . --fix"
 	},
 	"devDependencies": {
-		"@element-plus/nuxt": "^1.1.4",
 		"@nuxt/eslint": "1.11.0",
-		"element-plus": "^2.11.7",
 		"eslint": "9.39.1",
 		"nuxt": "^4.2.1",
 		"prettier": "3.7.4",


### PR DESCRIPTION
## Summary

Applies the updated design system from the Claude Design handoff to the Vue/Nuxt prediction tool, aligned with [prediction-tool#109](https://github.com/shenghaoc/prediction-tool/pull/109) (React).

- **Google Fonts**: DM Sans (body) + Lora (display) via `nuxt.config` head link
- **Design tokens**: CSS variables for light/dark themes (`#74685b` muted text, glassmorphic panels, mesh grid, orb glow)
- **Removed Element Plus**: Native `<select>`, `<input>`, and `<button>` elements with custom styling
- **Placeholder state**: Dashed-border guidance box when no prediction has been submitted
- **Awaiting state**: Price panel shows muted "Awaiting prediction" instead of $0
- **Custom metric cards**: Replaced `el-descriptions` with 18px-radius cards (uppercase labels)
- **Chart summary cards**: Plain styled divs with tabular-nums and proper spacing
- **Animations**: `settle` keyframe for price value, hover `translateY(-1px)` on buttons, pulse while loading
- **i18n**: Added `awaiting`, `predicting`, `placeholder_title`, `placeholder_body` (EN + ZH)

## Test plan

- [x] `bun run build` passes
- [x] `bun run lint` passes
- [ ] Verify light/dark theme toggle
- [ ] Verify EN/ZH language toggle
- [ ] Submit a prediction and confirm chart + price animation
- [ ] Confirm empty state shows placeholder before first prediction


Made with [Cursor](https://cursor.com)