### PR TITLE
⚡ Bolt: Remove @js-temporal/polyfill

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2023-11-20 - Removed @js-temporal/polyfill
+**Learning:** The `@js-temporal/polyfill` dependency was being used solely for simple string manipulation to generate a list of months and parse years. This added unnecessary weight to the client bundle without leveraging the library's more complex features.
+**Action:** Replace `Temporal` usage with standard JavaScript operations (like string splitting and loops) when only basic parsing or sequence generation is needed. This reduces bundle size while achieving the same results. Let the bundler handle tree-shaking rather than modifying `package.json` manually when dependencies shouldn't be altered according to issue instructions.

--- a/app/utils/lists.ts
+++ b/app/utils/lists.ts
@@ -1,5 +1,3 @@
-import { Temporal } from '@js-temporal/polyfill';
-
 export const ML_MODELS = ['Support Vector Regression', 'Ridge Regression'] as const;
 export type MLModel = (typeof ML_MODELS)[number];
 
@@ -78,15 +76,29 @@ export const FLAT_MODELS = [
 ] as const;
 export type FlatModel = (typeof FLAT_MODELS)[number];
 
-const PREDICTION_MONTH_START = Temporal.PlainYearMonth.from('2017-01');
-const PREDICTION_MONTH_END = Temporal.PlainYearMonth.from('2022-02');
+const PREDICTION_MONTH_START = '2017-01';
+const PREDICTION_MONTH_END = '2022-02';
 
-function generateMonths(start: Temporal.PlainYearMonth, end: Temporal.PlainYearMonth): string[] {
+function generateMonths(startStr: string, endStr: string): string[] {
+	const [startYearStr, startMonthStr] = startStr.split('-');
+	const [endYearStr, endMonthStr] = endStr.split('-');
+
+	const startYear = Number.parseInt(startYearStr!, 10);
+	const startMonth = Number.parseInt(startMonthStr!, 10);
+	const endYear = Number.parseInt(endYearStr!, 10);
+	const endMonth = Number.parseInt(endMonthStr!, 10);
+
 	const months: string[] = [];
-	let current = start;
-	while (Temporal.PlainYearMonth.compare(current, end) <= 0) {
-		months.push(current.toString());
-		current = current.add({ months: 1 });
+	let currentYear = startYear;
+	let currentMonth = startMonth;
+
+	while (currentYear < endYear || (currentYear === endYear && currentMonth <= endMonth)) {
+		months.push(`${currentYear}-${currentMonth.toString().padStart(2, '0')}`);
+		currentMonth++;
+		if (currentMonth > 12) {
+			currentMonth = 1;
+			currentYear++;
+		}
 	}
 	return months;
 }

--- a/app/utils/prediction.ts
+++ b/app/utils/prediction.ts
@@ -1,5 +1,3 @@
-import { Temporal } from '@js-temporal/polyfill';
-
 import {
 	FLAT_MODELS,
 	ML_MODELS,
@@ -34,9 +32,7 @@ export type ApiResponse = {
 
 export type PredictionTheme = ReturnType<typeof getPredictionTheme>;
 
-export const MAX_LEASE_COMMENCE_YEAR = Temporal.PlainYearMonth.from(
-	MONTHS[MONTHS.length - 1]!
-).year;
+export const MAX_LEASE_COMMENCE_YEAR = Number.parseInt(MONTHS[MONTHS.length - 1]!.slice(0, 4), 10);
 export const YEAR_OPTIONS = Array.from(
 	{ length: MAX_LEASE_COMMENCE_YEAR - 1960 + 1 },
 	(_, index) => MAX_LEASE_COMMENCE_YEAR - index


### PR DESCRIPTION
⚡ Bolt: Remove `@js-temporal/polyfill` to reduce client bundle size

💡 What: Replaced `@js-temporal/polyfill` usage with native JavaScript string splitting and looping for simple month sequence generation and year parsing.
🎯 Why: The polyfill was included solely for trivial date operations, adding unnecessary weight to the client bundle without leveraging its more complex features.
📊 Impact: Reduces client bundle size by eliminating the need to bundle a heavy polyfill library for simple logic.
🔬 Measurement: Verify the build with `npm run build` and ensure the output in `app/utils/lists.ts` and `app/utils/prediction.ts` functions exactly as before.

---
*PR created automatically by Jules for task [11671477900909414750](https://jules.google.com/task/11671477900909414750) started by @shenghaoc*