### PR TITLE
Migrate from radix-vue to reka-ui

### DIFF
--- a/app/app.vue
+++ b/app/app.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { TooltipProvider } from 'radix-vue';
+import { TooltipProvider } from 'reka-ui';
 </script>
 
 <template>

--- a/app/components/ui/Label.vue
+++ b/app/components/ui/Label.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { cn } from '~/lib/utils';
-import { Label, type LabelProps } from 'radix-vue';
+import { Label, type LabelProps } from 'reka-ui';
 
 defineProps<
 	LabelProps & {

--- a/app/components/ui/Select.vue
+++ b/app/components/ui/Select.vue
@@ -14,7 +14,7 @@ import {
 	SelectTrigger,
 	SelectValue,
 	SelectViewport
-} from 'radix-vue';
+} from 'reka-ui';
 import { Check, ChevronDown, ChevronUp } from '@lucide/vue';
 
 defineProps<{

--- a/app/components/ui/Separator.vue
+++ b/app/components/ui/Separator.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { cn } from '~/lib/utils';
-import { Separator, type SeparatorProps } from 'radix-vue';
+import { Separator, type SeparatorProps } from 'reka-ui';
 
 defineProps<
 	SeparatorProps & {

--- a/app/components/ui/Tooltip.vue
+++ b/app/components/ui/Tooltip.vue
@@ -6,7 +6,7 @@ import {
 	TooltipPortal,
 	TooltipRoot,
 	TooltipTrigger
-} from 'radix-vue';
+} from 'reka-ui';
 
 defineProps<{
 	class?: string;

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
 				"chart.js": "^4.5.1",
 				"class-variance-authority": "^0.7.1",
 				"clsx": "^2.1.1",
-				"radix-vue": "^1.9.17",
+				"reka-ui": "^2.9.8",
 				"tailwind-merge": "^3.6.0",
 				"tailwindcss": "^4.3.0",
 				"vue-chartjs": "^5.3.2"
@@ -3049,6 +3049,28 @@
 				}
 			}
 		},
+		"node_modules/@nuxt/cli/node_modules/cac": {
+			"version": "6.7.14",
+			"resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+			"integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+			"license": "MIT",
+			"optional": true,
+			"peer": true,
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/@nuxt/cli/node_modules/commander": {
+			"version": "13.1.0",
+			"resolved": "https://registry.npmjs.org/commander/-/commander-13.1.0.tgz",
+			"integrity": "sha512-/rFeCpNJQbhSZjGVwO9RFV3xPqbnERS8MmIQzCtD/zl6gpJuV/bMLuN92oG3F7d8oDEHHRrujSXNUr8fpjntKw==",
+			"license": "MIT",
+			"optional": true,
+			"peer": true,
+			"engines": {
+				"node": ">=18"
+			}
+		},
 		"node_modules/@nuxt/devalue": {
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/@nuxt/devalue/-/devalue-2.0.2.tgz",
@@ -3746,9 +3768,6 @@
 			"cpu": [
 				"arm64"
 			],
-			"libc": [
-				"glibc"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -3764,9 +3783,6 @@
 			"integrity": "sha512-M7iwBGmYJTx+pKOYFjI0buop4gJvlmcVzFGaXPt21DKpQkbQZG1f63Yg7LloIYT/t9yLxCw0Lhfx/RFlAlMSjA==",
 			"cpu": [
 				"arm64"
-			],
-			"libc": [
-				"musl"
 			],
 			"license": "MIT",
 			"optional": true,
@@ -3784,9 +3800,6 @@
 			"cpu": [
 				"ppc64"
 			],
-			"libc": [
-				"glibc"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -3802,9 +3815,6 @@
 			"integrity": "sha512-gyHjOTFpg9bTTYjxPmQirvufb89+VdZwVfcMtAUyPr6F5H8ZswvCQshK4qOW+Q+2Xyb33hduRgY/eFHJQjU/vQ==",
 			"cpu": [
 				"riscv64"
-			],
-			"libc": [
-				"glibc"
 			],
 			"license": "MIT",
 			"optional": true,
@@ -3822,9 +3832,6 @@
 			"cpu": [
 				"riscv64"
 			],
-			"libc": [
-				"musl"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -3840,9 +3847,6 @@
 			"integrity": "sha512-BdzTmqxfxoYkpgokoLaSnOX6T+R3/goL42klre2tnG+kHbG2TXS0VN+P5BPofH1axdKOHy5ei4ENZrjmCOt2lA==",
 			"cpu": [
 				"s390x"
-			],
-			"libc": [
-				"glibc"
 			],
 			"license": "MIT",
 			"optional": true,
@@ -3860,9 +3864,6 @@
 			"cpu": [
 				"x64"
 			],
-			"libc": [
-				"glibc"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -3878,9 +3879,6 @@
 			"integrity": "sha512-4NehAe404MRdoZVS9DW8C5XbJwbXIc/KfVlYdpi5vE4081zc9Y0YzKVqyOYj/Puye7/Do+ohaONBFWlEHYl9hw==",
 			"cpu": [
 				"x64"
-			],
-			"libc": [
-				"musl"
 			],
 			"license": "MIT",
 			"optional": true,
@@ -4101,9 +4099,6 @@
 			"cpu": [
 				"arm64"
 			],
-			"libc": [
-				"glibc"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -4119,9 +4114,6 @@
 			"integrity": "sha512-dPSjyd0gQ9dE3mpdJi0BHNJaqQz4V7mVW6Fbs6jRSiGnrxwGfXdMJFInXoJ49B3k5Zhfa9Is9Ixp6St7c6ouCA==",
 			"cpu": [
 				"arm64"
-			],
-			"libc": [
-				"musl"
 			],
 			"license": "MIT",
 			"optional": true,
@@ -4139,9 +4131,6 @@
 			"cpu": [
 				"ppc64"
 			],
-			"libc": [
-				"glibc"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -4157,9 +4146,6 @@
 			"integrity": "sha512-jjSiG9H8ya/U3igW5DdIBFIDwhffF7Vbc7th2tcHV73eg0DQz75n36a9RmQ1/0aS9vknUuNtY6SODr8/gmuzsQ==",
 			"cpu": [
 				"riscv64"
-			],
-			"libc": [
-				"glibc"
 			],
 			"license": "MIT",
 			"optional": true,
@@ -4177,9 +4163,6 @@
 			"cpu": [
 				"riscv64"
 			],
-			"libc": [
-				"musl"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -4195,9 +4178,6 @@
 			"integrity": "sha512-caJnVw5PG8v339zAyHgA7p34xXa3A4Kc9VyrDgsT1znr51qacaUv4BRlgRi0qkqxRWXYNVFfsbU2g0t1qS7E9w==",
 			"cpu": [
 				"s390x"
-			],
-			"libc": [
-				"glibc"
 			],
 			"license": "MIT",
 			"optional": true,
@@ -4215,9 +4195,6 @@
 			"cpu": [
 				"x64"
 			],
-			"libc": [
-				"glibc"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -4233,9 +4210,6 @@
 			"integrity": "sha512-NjYtwl9ijp34iisHxYBvE7nii1Ac0QPP3doHv8MQHhDA3zjUcDCROuBNybfaEYCxnJ1aF+cAPqsyeopnAGsyuQ==",
 			"cpu": [
 				"x64"
-			],
-			"libc": [
-				"musl"
 			],
 			"license": "MIT",
 			"optional": true,
@@ -6745,12 +6719,6 @@
 			"integrity": "sha512-60BCwRFOZCQhDncwQdxxeOEEkbc5dIMccYLwbxsS4TUNeVECQ/pBJ0j09mrHOl/JJvpRPGwO9SvE4nR2Nb/a4Q==",
 			"license": "MIT"
 		},
-		"node_modules/@types/web-bluetooth": {
-			"version": "0.0.20",
-			"resolved": "https://registry.npmjs.org/@types/web-bluetooth/-/web-bluetooth-0.0.20.tgz",
-			"integrity": "sha512-g9gZnnXVq7gM7v3tJCWV/qw7w+KeOlSHAhgF9RytFyifW6AF61hdT2ucrYhPq9hLs5JIryeupHV3qGk95dH9ow==",
-			"license": "MIT"
-		},
 		"node_modules/@typescript-eslint/eslint-plugin": {
 			"version": "8.60.0",
 			"resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.60.0.tgz",
@@ -7654,56 +7622,6 @@
 			"integrity": "sha512-24uqU4OIiX29ryC3MeWid/Xf2fa2EFRUVLb77nRhk+UrTVrh/XiGtFAFmJBAtBRbjwNdsPRP+jj/OL27Eg1NDA==",
 			"license": "MIT"
 		},
-		"node_modules/@vueuse/core": {
-			"version": "10.11.1",
-			"resolved": "https://registry.npmjs.org/@vueuse/core/-/core-10.11.1.tgz",
-			"integrity": "sha512-guoy26JQktXPcz+0n3GukWIy/JDNKti9v6VEMu6kV2sYBsWuGiTU8OWdg+ADfUbHg3/3DlqySDe7JmdHrktiww==",
-			"license": "MIT",
-			"dependencies": {
-				"@types/web-bluetooth": "^0.0.20",
-				"@vueuse/metadata": "10.11.1",
-				"@vueuse/shared": "10.11.1",
-				"vue-demi": ">=0.14.8"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/antfu"
-			}
-		},
-		"node_modules/@vueuse/core/node_modules/vue-demi": {
-			"version": "0.14.10",
-			"resolved": "https://registry.npmjs.org/vue-demi/-/vue-demi-0.14.10.tgz",
-			"integrity": "sha512-nMZBOwuzabUO0nLgIcc6rycZEebF6eeUfaiQx9+WSk8e29IbLvPU9feI6tqW4kTo3hvoYAJkMh8n8D0fuISphg==",
-			"hasInstallScript": true,
-			"license": "MIT",
-			"bin": {
-				"vue-demi-fix": "bin/vue-demi-fix.js",
-				"vue-demi-switch": "bin/vue-demi-switch.js"
-			},
-			"engines": {
-				"node": ">=12"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/antfu"
-			},
-			"peerDependencies": {
-				"@vue/composition-api": "^1.0.0-rc.1",
-				"vue": "^3.0.0-0 || ^2.6.0"
-			},
-			"peerDependenciesMeta": {
-				"@vue/composition-api": {
-					"optional": true
-				}
-			}
-		},
-		"node_modules/@vueuse/metadata": {
-			"version": "10.11.1",
-			"resolved": "https://registry.npmjs.org/@vueuse/metadata/-/metadata-10.11.1.tgz",
-			"integrity": "sha512-IGa5FXd003Ug1qAZmyE8wF3sJ81xGLSqTqtQ6jaVfkeZ4i5kS2mwQF61yhVqojRnenVew5PldLyRgvdl4YYuSw==",
-			"license": "MIT",
-			"funding": {
-				"url": "https://github.com/sponsors/antfu"
-			}
-		},
 		"node_modules/@vueuse/nuxt": {
 			"version": "14.3.0",
 			"resolved": "https://registry.npmjs.org/@vueuse/nuxt/-/nuxt-14.3.0.tgz",
@@ -7765,44 +7683,6 @@
 			},
 			"peerDependencies": {
 				"vue": "^3.5.0"
-			}
-		},
-		"node_modules/@vueuse/shared": {
-			"version": "10.11.1",
-			"resolved": "https://registry.npmjs.org/@vueuse/shared/-/shared-10.11.1.tgz",
-			"integrity": "sha512-LHpC8711VFZlDaYUXEBbFBCQ7GS3dVU9mjOhhMhXP6txTV4EhYQg/KGnQuvt/sPAtoUKq7VVUnL6mVtFoL42sA==",
-			"license": "MIT",
-			"dependencies": {
-				"vue-demi": ">=0.14.8"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/antfu"
-			}
-		},
-		"node_modules/@vueuse/shared/node_modules/vue-demi": {
-			"version": "0.14.10",
-			"resolved": "https://registry.npmjs.org/vue-demi/-/vue-demi-0.14.10.tgz",
-			"integrity": "sha512-nMZBOwuzabUO0nLgIcc6rycZEebF6eeUfaiQx9+WSk8e29IbLvPU9feI6tqW4kTo3hvoYAJkMh8n8D0fuISphg==",
-			"hasInstallScript": true,
-			"license": "MIT",
-			"bin": {
-				"vue-demi-fix": "bin/vue-demi-fix.js",
-				"vue-demi-switch": "bin/vue-demi-switch.js"
-			},
-			"engines": {
-				"node": ">=12"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/antfu"
-			},
-			"peerDependencies": {
-				"@vue/composition-api": "^1.0.0-rc.1",
-				"vue": "^3.0.0-0 || ^2.6.0"
-			},
-			"peerDependenciesMeta": {
-				"@vue/composition-api": {
-					"optional": true
-				}
 			}
 		},
 		"node_modules/abbrev": {
@@ -13992,46 +13872,6 @@
 			],
 			"license": "MIT"
 		},
-		"node_modules/radix-vue": {
-			"version": "1.9.17",
-			"resolved": "https://registry.npmjs.org/radix-vue/-/radix-vue-1.9.17.tgz",
-			"integrity": "sha512-mVCu7I2vXt1L2IUYHTt0sZMz7s1K2ZtqKeTIxG3yC5mMFfLBG4FtE1FDeRMpDd+Hhg/ybi9+iXmAP1ISREndoQ==",
-			"license": "MIT",
-			"dependencies": {
-				"@floating-ui/dom": "^1.6.7",
-				"@floating-ui/vue": "^1.1.0",
-				"@internationalized/date": "^3.5.4",
-				"@internationalized/number": "^3.5.3",
-				"@tanstack/vue-virtual": "^3.8.1",
-				"@vueuse/core": "^10.11.0",
-				"@vueuse/shared": "^10.11.0",
-				"aria-hidden": "^1.2.4",
-				"defu": "^6.1.4",
-				"fast-deep-equal": "^3.1.3",
-				"nanoid": "^5.0.7"
-			},
-			"peerDependencies": {
-				"vue": ">= 3.2.0"
-			}
-		},
-		"node_modules/radix-vue/node_modules/nanoid": {
-			"version": "5.1.11",
-			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-5.1.11.tgz",
-			"integrity": "sha512-v+KEsUv2ps74PaSKv0gHTxTCgMXOIfBEbaqa6w6ISIGC7ZsvHN4N9oJ8d4cmf0n5oTzQz2SLmThbQWhjd/8eKg==",
-			"funding": [
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/ai"
-				}
-			],
-			"license": "MIT",
-			"bin": {
-				"nanoid": "bin/nanoid.js"
-			},
-			"engines": {
-				"node": "^18 || >=20"
-			}
-		},
 		"node_modules/radix3": {
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/radix3/-/radix3-1.1.2.tgz",
@@ -14190,6 +14030,75 @@
 			},
 			"bin": {
 				"regjsparser": "bin/parser"
+			}
+		},
+		"node_modules/reka-ui": {
+			"version": "2.9.8",
+			"resolved": "https://registry.npmjs.org/reka-ui/-/reka-ui-2.9.8.tgz",
+			"integrity": "sha512-7dxaBJ6nQ0zOQZXPV45219tTEgZPstmihBLS9ABPhSiPiJ8SiF0sacfZHFaBptS0v9N4tzsevq+8MNBpE4p5JQ==",
+			"license": "MIT",
+			"dependencies": {
+				"@floating-ui/dom": "^1.6.13",
+				"@floating-ui/vue": "^1.1.6",
+				"@internationalized/date": "^3.5.0",
+				"@internationalized/number": "^3.5.0",
+				"@tanstack/vue-virtual": "^3.12.0",
+				"@vueuse/core": "^14.1.0",
+				"@vueuse/shared": "^14.1.0",
+				"aria-hidden": "^1.2.4",
+				"defu": "^6.1.5",
+				"ohash": "^2.0.11"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/zernonia"
+			},
+			"peerDependencies": {
+				"vue": ">= 3.4.0"
+			}
+		},
+		"node_modules/reka-ui/node_modules/@types/web-bluetooth": {
+			"version": "0.0.21",
+			"resolved": "https://registry.npmjs.org/@types/web-bluetooth/-/web-bluetooth-0.0.21.tgz",
+			"integrity": "sha512-oIQLCGWtcFZy2JW77j9k8nHzAOpqMHLQejDA48XXMWH6tjCQHz5RCFz1bzsmROyL6PUm+LLnUiI4BCn221inxA==",
+			"license": "MIT"
+		},
+		"node_modules/reka-ui/node_modules/@vueuse/core": {
+			"version": "14.3.0",
+			"resolved": "https://registry.npmjs.org/@vueuse/core/-/core-14.3.0.tgz",
+			"integrity": "sha512-aHfz47g0ZhMtTVHmIzMVpJy8ePhhOy68GY5bv110+5DVtZ+W7BsOx+m61UNQqfrWyPztIHIanWa3E2tib3NFIw==",
+			"license": "MIT",
+			"dependencies": {
+				"@types/web-bluetooth": "^0.0.21",
+				"@vueuse/metadata": "14.3.0",
+				"@vueuse/shared": "14.3.0"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/antfu"
+			},
+			"peerDependencies": {
+				"vue": "^3.5.0"
+			}
+		},
+		"node_modules/reka-ui/node_modules/@vueuse/metadata": {
+			"version": "14.3.0",
+			"resolved": "https://registry.npmjs.org/@vueuse/metadata/-/metadata-14.3.0.tgz",
+			"integrity": "sha512-BwxmbAzwAVF50+MW57GXOUEV61nFBGnlBvrTqj49PqWJu3uw7hdu72ztXeZ33RdZtDY6kO+bfCAE1PCn88Tktw==",
+			"license": "MIT",
+			"funding": {
+				"url": "https://github.com/sponsors/antfu"
+			}
+		},
+		"node_modules/reka-ui/node_modules/@vueuse/shared": {
+			"version": "14.3.0",
+			"resolved": "https://registry.npmjs.org/@vueuse/shared/-/shared-14.3.0.tgz",
+			"integrity": "sha512-bZpge9eSXwa4ToSiqJ7j6KRwhAsneMFoSz3LMWKQDkqimm3D/tbFlrklrs/IOqC8tEcYmXQZJ6N0UrjhBirVCg==",
+			"license": "MIT",
+			"funding": {
+				"url": "https://github.com/sponsors/antfu"
+			},
+			"peerDependencies": {
+				"vue": "^3.5.0"
 			}
 		},
 		"node_modules/reserved-identifiers": {

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
 		"chart.js": "^4.5.1",
 		"class-variance-authority": "^0.7.1",
 		"clsx": "^2.1.1",
-		"radix-vue": "^1.9.17",
+		"reka-ui": "^2.9.8",
 		"tailwind-merge": "^3.6.0",
 		"tailwindcss": "^4.3.0",
 		"vue-chartjs": "^5.3.2"


### PR DESCRIPTION
Radix Vue is deprecated and was rebranded as Reka UI in its v2 evolution;
shadcn-vue's registry now targets Reka UI. Swap the dependency and update
all imports.

- package.json: radix-vue ^1.9.17 -> reka-ui ^2.9.8 (lockfile regenerated)
- Update imports in app.vue and the Tooltip/Label/Select/Separator UI
  primitives from 'radix-vue' to 'reka-ui' (component names are unchanged)

The Reka UI API breaking changes do not apply here: no --radix-* CSS
variables or [data-radix-*] attributes are used, and there is no
Combobox/Checkbox/Toggle/forceMount usage (the v-model:checked/pressed
renames and Combobox filtering refactor are therefore moot).

Verified with nuxt typecheck, eslint, and nuxt build (all pass).