### PR TITLE
Refactor prediction flow: Zod, TanStack Form, ECharts, Nitro proxy

### DIFF
--- a/app/components/prediction/PredictionForm.vue
+++ b/app/components/prediction/PredictionForm.vue
@@ -104,50 +104,45 @@ const leaseYearOptions = computed(() =>
 			</FormField>
 
 			<FormField v-slot="{ field }" name="floor_area_sqm">
-				<template
-					v-for="floorAreaError in [fieldError('floor_area_sqm', field.state.meta.errors)]"
-					:key="floorAreaError || 'floor-area'"
-				>
-					<div class="grid gap-1.5">
-						<label
-							for="input-floor_area"
-							class="text-[11px] font-bold uppercase tracking-wider text-muted-foreground"
+				<div class="grid gap-1.5">
+					<label
+						for="input-floor_area"
+						class="text-[11px] font-bold uppercase tracking-wider text-muted-foreground"
+					>
+						{{ t('floor_area') }}
+					</label>
+					<div class="flex">
+						<Input
+							id="input-floor_area"
+							type="number"
+							inputmode="decimal"
+							enterkeyhint="done"
+							:min="20"
+							:max="300"
+							step="any"
+							:model-value="field.state.value == null || Number.isNaN(field.state.value) ? '' : String(field.state.value)"
+							:placeholder="t('enter_floor_area')"
+							:error="fieldError('floor_area_sqm', field.state.meta.errors)"
+							class="relative rounded-r-none border-r-0 focus-visible:z-10"
+							@input="
+								field.handleChange(
+									($event.target as HTMLInputElement).value === ''
+										? Number.NaN
+										: Number(($event.target as HTMLInputElement).value)
+								)
+							"
+						/>
+						<span
+							class="inline-flex h-8 items-center rounded-r-sm border border-input bg-secondary px-3 text-xs font-semibold text-muted-foreground"
 						>
-							{{ t('floor_area') }}
-						</label>
-						<div class="flex">
-							<Input
-								id="input-floor_area"
-								type="number"
-								inputmode="decimal"
-								enterkeyhint="done"
-								:min="20"
-								:max="300"
-								step="any"
-								:model-value="Number.isNaN(field.state.value) ? '' : String(field.state.value)"
-								:placeholder="t('enter_floor_area')"
-								:error="floorAreaError"
-								class="relative rounded-r-none border-r-0 focus-visible:z-10"
-								@input="
-									field.handleChange(
-										($event.target as HTMLInputElement).value === ''
-											? Number.NaN
-											: Number(($event.target as HTMLInputElement).value)
-									)
-								"
-							/>
-							<span
-								class="inline-flex h-8 items-center rounded-r-sm border border-input bg-secondary px-3 text-xs font-semibold text-muted-foreground"
-							>
-								<span class="sr-only">{{ t('floor_area_unit') }}</span>
-								<span aria-hidden>m²</span>
-							</span>
-						</div>
-						<p v-if="floorAreaError" class="text-xs text-destructive">
-							{{ floorAreaError }}
-						</p>
+							<span class="sr-only">{{ t('floor_area_unit') }}</span>
+							<span aria-hidden>m²</span>
+						</span>
 					</div>
-				</template>
+					<p v-if="fieldError('floor_area_sqm', field.state.meta.errors)" class="text-xs text-destructive">
+						{{ fieldError('floor_area_sqm', field.state.meta.errors) }}
+					</p>
+				</div>
 			</FormField>
 		</div>
 
@@ -156,7 +151,7 @@ const leaseYearOptions = computed(() =>
 				:label="t('lease_commence_date')"
 				label-for="input-lease_commence_date"
 				:error="fieldError('lease_commence_date', field.state.meta.errors)"
-				:model-value="String(field.state.value as number)"
+				:model-value="field.state.value ? String(field.state.value) : ''"
 				:placeholder="t('select_year')"
 				:items="leaseYearOptions"
 				@update:model-value="field.handleChange(Number($event))"

--- a/app/components/prediction/PredictionForm.vue
+++ b/app/components/prediction/PredictionForm.vue
@@ -1,9 +1,11 @@
 <script setup lang="ts">
 import { computed } from 'vue';
 import { Loader2 } from '@lucide/vue';
+import { useField } from 'vee-validate';
+
 import { FLAT_MODELS, ML_MODELS, STOREY_RANGES, TOWNS } from '~/utils/lists';
-import { YEAR_OPTIONS, type FieldType } from '~/utils/prediction';
-import type { FieldUpdate } from '~/composables/usePredictionForm';
+import { YEAR_OPTIONS } from '~/utils/prediction';
+import { translatePredictionFieldError } from '~/utils/predictionValidation';
 import Button from '~/components/ui/Button.vue';
 import Input from '~/components/ui/Input.vue';
 import FormSelect from '~/components/ui/FormSelect.vue';
@@ -11,8 +13,6 @@ import FormSelect from '~/components/ui/FormSelect.vue';
 const { t } = useI18n();
 
 defineProps<{
-	form: FieldType;
-	fieldErrors: Record<keyof FieldType, string>;
 	loading: boolean;
 	errorMessage: string;
 }>();
@@ -20,21 +20,34 @@ defineProps<{
 const emit = defineEmits<{
 	submit: [];
 	reset: [];
-	updateField: [payload: FieldUpdate];
 }>();
+
+const { value: mlModel, errorMessage: mlModelError } = useField<string>('ml_model');
+const { value: town, errorMessage: townError } = useField<string>('town');
+const { value: storeyRange, errorMessage: storeyRangeError } = useField<string>('storey_range');
+const { value: flatModel, errorMessage: flatModelError } = useField<string>('flat_model');
+const { value: floorAreaSqm, errorMessage: floorAreaError } = useField<number>('floor_area_sqm');
+const { value: leaseCommenceDate, errorMessage: leaseCommenceDateError } =
+	useField<number>('lease_commence_date');
+
+function fieldError(
+	field:
+		| 'ml_model'
+		| 'town'
+		| 'storey_range'
+		| 'flat_model'
+		| 'floor_area_sqm'
+		| 'lease_commence_date',
+	message: string | undefined
+) {
+	return translatePredictionFieldError(field, message, t);
+}
 
 function optionLabel(
 	group: 'ml_models' | 'towns' | 'storey_ranges' | 'flat_models',
 	value: string
 ) {
 	return t(`${group}.${value}`);
-}
-
-function updateField<K extends keyof FieldType>(key: K, value: FieldType[K]) {
-	// `key`/`value` are correlated through `K`, but TypeScript cannot express that
-	// the constructed object is a single member of the `FieldUpdate` union — the
-	// assertion is the standard, unavoidable bridge for correlated unions.
-	emit('updateField', { key, value } as FieldUpdate);
 }
 
 const mlModelOptions = computed(() =>
@@ -59,40 +72,40 @@ const leaseYearOptions = computed(() =>
 		<FormSelect
 			:label="t('ml_model')"
 			label-for="input-ml_model"
-			:error="fieldErrors.ml_model"
-			:model-value="form.ml_model"
+			:error="fieldError('ml_model', mlModelError)"
+			:model-value="mlModel"
 			:placeholder="t('select_ml_model')"
 			:items="mlModelOptions"
-			@update:model-value="updateField('ml_model', $event)"
+			@update:model-value="mlModel = $event"
 		/>
 
 		<div class="grid grid-cols-2 gap-3 max-sm:grid-cols-1">
 			<FormSelect
 				:label="t('town')"
 				label-for="input-town"
-				:error="fieldErrors.town"
-				:model-value="form.town"
+				:error="fieldError('town', townError)"
+				:model-value="town"
 				:placeholder="t('select_town')"
 				:items="townOptions"
-				@update:model-value="updateField('town', $event)"
+				@update:model-value="town = $event"
 			/>
 			<FormSelect
 				:label="t('storey_range')"
 				label-for="input-storey_range"
-				:error="fieldErrors.storey_range"
-				:model-value="form.storey_range"
+				:error="fieldError('storey_range', storeyRangeError)"
+				:model-value="storeyRange"
 				:placeholder="t('select_storey_range')"
 				:items="storeyOptions"
-				@update:model-value="updateField('storey_range', $event)"
+				@update:model-value="storeyRange = $event"
 			/>
 			<FormSelect
 				:label="t('flat_model')"
 				label-for="input-flat_model"
-				:error="fieldErrors.flat_model"
-				:model-value="form.flat_model"
+				:error="fieldError('flat_model', flatModelError)"
+				:model-value="flatModel"
 				:placeholder="t('select_flat_model')"
 				:items="flatModelOptions"
-				@update:model-value="updateField('flat_model', $event)"
+				@update:model-value="flatModel = $event"
 			/>
 			<div class="grid gap-1.5">
 				<label
@@ -110,17 +123,15 @@ const leaseYearOptions = computed(() =>
 						:min="20"
 						:max="300"
 						:step="1"
-						:model-value="Number.isNaN(form.floor_area_sqm) ? '' : String(form.floor_area_sqm)"
+						:model-value="Number.isNaN(floorAreaSqm) ? '' : String(floorAreaSqm)"
 						:placeholder="t('enter_floor_area')"
-						:error="fieldErrors.floor_area_sqm"
+						:error="fieldError('floor_area_sqm', floorAreaError)"
 						class="relative rounded-r-none border-r-0 focus-visible:z-10"
 						@input="
-							updateField(
-								'floor_area_sqm',
+							floorAreaSqm =
 								($event.target as HTMLInputElement).value === ''
 									? Number.NaN
 									: Number(($event.target as HTMLInputElement).value)
-							)
 						"
 					/>
 					<span
@@ -130,8 +141,8 @@ const leaseYearOptions = computed(() =>
 						<span aria-hidden>m²</span>
 					</span>
 				</div>
-				<p v-if="fieldErrors.floor_area_sqm" class="text-xs text-destructive">
-					{{ fieldErrors.floor_area_sqm }}
+				<p v-if="fieldError('floor_area_sqm', floorAreaError)" class="text-xs text-destructive">
+					{{ fieldError('floor_area_sqm', floorAreaError) }}
 				</p>
 			</div>
 		</div>
@@ -139,11 +150,11 @@ const leaseYearOptions = computed(() =>
 		<FormSelect
 			:label="t('lease_commence_date')"
 			label-for="input-lease_commence_date"
-			:error="fieldErrors.lease_commence_date"
-			:model-value="String(form.lease_commence_date)"
+			:error="fieldError('lease_commence_date', leaseCommenceDateError)"
+			:model-value="String(leaseCommenceDate)"
 			:placeholder="t('select_year')"
 			:items="leaseYearOptions"
-			@update:model-value="updateField('lease_commence_date', Number($event))"
+			@update:model-value="leaseCommenceDate = Number($event)"
 		/>
 
 		<div class="grid grid-cols-2 gap-2.5 max-sm:grid-cols-1">

--- a/app/components/prediction/PredictionForm.vue
+++ b/app/components/prediction/PredictionForm.vue
@@ -104,48 +104,50 @@ const leaseYearOptions = computed(() =>
 			</FormField>
 
 			<FormField v-slot="{ field }" name="floor_area_sqm">
-				<div class="grid gap-1.5">
-					<label
-						for="input-floor_area"
-						class="text-[11px] font-bold uppercase tracking-wider text-muted-foreground"
-					>
-						{{ t('floor_area') }}
-					</label>
-					<div class="flex">
-						<Input
-							id="input-floor_area"
-							type="number"
-							inputmode="numeric"
-							enterkeyhint="done"
-							:min="20"
-							:max="300"
-							:step="1"
-							:model-value="Number.isNaN(field.state.value) ? '' : String(field.state.value)"
-							:placeholder="t('enter_floor_area')"
-							:error="fieldError('floor_area_sqm', field.state.meta.errors)"
-							class="relative rounded-r-none border-r-0 focus-visible:z-10"
-							@input="
-								field.handleChange(
-									($event.target as HTMLInputElement).value === ''
-										? Number.NaN
-										: Number(($event.target as HTMLInputElement).value)
-								)
-							"
-						/>
-						<span
-							class="inline-flex h-8 items-center rounded-r-sm border border-input bg-secondary px-3 text-xs font-semibold text-muted-foreground"
+				<template
+					v-for="floorAreaError in [fieldError('floor_area_sqm', field.state.meta.errors)]"
+					:key="floorAreaError || 'floor-area'"
+				>
+					<div class="grid gap-1.5">
+						<label
+							for="input-floor_area"
+							class="text-[11px] font-bold uppercase tracking-wider text-muted-foreground"
 						>
-							<span class="sr-only">{{ t('floor_area_unit') }}</span>
-							<span aria-hidden>m²</span>
-						</span>
+							{{ t('floor_area') }}
+						</label>
+						<div class="flex">
+							<Input
+								id="input-floor_area"
+								type="number"
+								inputmode="decimal"
+								enterkeyhint="done"
+								:min="20"
+								:max="300"
+								step="any"
+								:model-value="Number.isNaN(field.state.value) ? '' : String(field.state.value)"
+								:placeholder="t('enter_floor_area')"
+								:error="floorAreaError"
+								class="relative rounded-r-none border-r-0 focus-visible:z-10"
+								@input="
+									field.handleChange(
+										($event.target as HTMLInputElement).value === ''
+											? Number.NaN
+											: Number(($event.target as HTMLInputElement).value)
+									)
+								"
+							/>
+							<span
+								class="inline-flex h-8 items-center rounded-r-sm border border-input bg-secondary px-3 text-xs font-semibold text-muted-foreground"
+							>
+								<span class="sr-only">{{ t('floor_area_unit') }}</span>
+								<span aria-hidden>m²</span>
+							</span>
+						</div>
+						<p v-if="floorAreaError" class="text-xs text-destructive">
+							{{ floorAreaError }}
+						</p>
 					</div>
-					<p
-						v-if="fieldError('floor_area_sqm', field.state.meta.errors)"
-						class="text-xs text-destructive"
-					>
-						{{ fieldError('floor_area_sqm', field.state.meta.errors) }}
-					</p>
-				</div>
+				</template>
 			</FormField>
 		</div>
 

--- a/app/components/prediction/PredictionForm.vue
+++ b/app/components/prediction/PredictionForm.vue
@@ -1,10 +1,10 @@
 <script setup lang="ts">
 import { computed } from 'vue';
 import { Loader2 } from '@lucide/vue';
-import { useField } from 'vee-validate';
 
+import type { PredictionFormHandle } from '~/composables/usePredictionForm';
 import { FLAT_MODELS, ML_MODELS, STOREY_RANGES, TOWNS } from '~/utils/lists';
-import { YEAR_OPTIONS } from '~/utils/prediction';
+import { YEAR_OPTIONS, type FieldType } from '~/utils/prediction';
 import { translatePredictionFieldError } from '~/utils/predictionValidation';
 import Button from '~/components/ui/Button.vue';
 import Input from '~/components/ui/Input.vue';
@@ -12,35 +12,20 @@ import FormSelect from '~/components/ui/FormSelect.vue';
 
 const { t } = useI18n();
 
-defineProps<{
+const props = defineProps<{
+	form: PredictionFormHandle;
 	loading: boolean;
 	errorMessage: string;
 }>();
 
+const FormField = props.form.Field;
+
 const emit = defineEmits<{
-	submit: [];
 	reset: [];
 }>();
 
-const { value: mlModel, errorMessage: mlModelError } = useField<string>('ml_model');
-const { value: town, errorMessage: townError } = useField<string>('town');
-const { value: storeyRange, errorMessage: storeyRangeError } = useField<string>('storey_range');
-const { value: flatModel, errorMessage: flatModelError } = useField<string>('flat_model');
-const { value: floorAreaSqm, errorMessage: floorAreaError } = useField<number>('floor_area_sqm');
-const { value: leaseCommenceDate, errorMessage: leaseCommenceDateError } =
-	useField<number>('lease_commence_date');
-
-function fieldError(
-	field:
-		| 'ml_model'
-		| 'town'
-		| 'storey_range'
-		| 'flat_model'
-		| 'floor_area_sqm'
-		| 'lease_commence_date',
-	message: string | undefined
-) {
-	return translatePredictionFieldError(field, message, t);
+function fieldError(field: keyof FieldType, errors: unknown[] | undefined) {
+	return translatePredictionFieldError(field, errors, t);
 }
 
 function optionLabel(
@@ -68,94 +53,113 @@ const leaseYearOptions = computed(() =>
 </script>
 
 <template>
-	<form class="flex flex-col gap-4" @submit.prevent="emit('submit')">
-		<FormSelect
-			:label="t('ml_model')"
-			label-for="input-ml_model"
-			:error="fieldError('ml_model', mlModelError)"
-			:model-value="mlModel"
-			:placeholder="t('select_ml_model')"
-			:items="mlModelOptions"
-			@update:model-value="mlModel = $event"
-		/>
+	<form class="flex flex-col gap-4" @submit.prevent="props.form.handleSubmit">
+		<FormField v-slot="{ field }" name="ml_model">
+			<FormSelect
+				:label="t('ml_model')"
+				label-for="input-ml_model"
+				:error="fieldError('ml_model', field.state.meta.errors)"
+				:model-value="field.state.value"
+				:placeholder="t('select_ml_model')"
+				:items="mlModelOptions"
+				@update:model-value="field.handleChange"
+			/>
+		</FormField>
 
 		<div class="grid grid-cols-2 gap-3 max-sm:grid-cols-1">
-			<FormSelect
-				:label="t('town')"
-				label-for="input-town"
-				:error="fieldError('town', townError)"
-				:model-value="town"
-				:placeholder="t('select_town')"
-				:items="townOptions"
-				@update:model-value="town = $event"
-			/>
-			<FormSelect
-				:label="t('storey_range')"
-				label-for="input-storey_range"
-				:error="fieldError('storey_range', storeyRangeError)"
-				:model-value="storeyRange"
-				:placeholder="t('select_storey_range')"
-				:items="storeyOptions"
-				@update:model-value="storeyRange = $event"
-			/>
-			<FormSelect
-				:label="t('flat_model')"
-				label-for="input-flat_model"
-				:error="fieldError('flat_model', flatModelError)"
-				:model-value="flatModel"
-				:placeholder="t('select_flat_model')"
-				:items="flatModelOptions"
-				@update:model-value="flatModel = $event"
-			/>
-			<div class="grid gap-1.5">
-				<label
-					for="input-floor_area"
-					class="text-[11px] font-bold uppercase tracking-wider text-muted-foreground"
-				>
-					{{ t('floor_area') }}
-				</label>
-				<div class="flex">
-					<Input
-						id="input-floor_area"
-						type="number"
-						inputmode="numeric"
-						enterkeyhint="done"
-						:min="20"
-						:max="300"
-						:step="1"
-						:model-value="Number.isNaN(floorAreaSqm) ? '' : String(floorAreaSqm)"
-						:placeholder="t('enter_floor_area')"
-						:error="fieldError('floor_area_sqm', floorAreaError)"
-						class="relative rounded-r-none border-r-0 focus-visible:z-10"
-						@input="
-							floorAreaSqm =
-								($event.target as HTMLInputElement).value === ''
-									? Number.NaN
-									: Number(($event.target as HTMLInputElement).value)
-						"
-					/>
-					<span
-						class="inline-flex h-8 items-center rounded-r-sm border border-input bg-secondary px-3 text-xs font-semibold text-muted-foreground"
+			<FormField v-slot="{ field }" name="town">
+				<FormSelect
+					:label="t('town')"
+					label-for="input-town"
+					:error="fieldError('town', field.state.meta.errors)"
+					:model-value="field.state.value"
+					:placeholder="t('select_town')"
+					:items="townOptions"
+					@update:model-value="field.handleChange"
+				/>
+			</FormField>
+
+			<FormField v-slot="{ field }" name="storey_range">
+				<FormSelect
+					:label="t('storey_range')"
+					label-for="input-storey_range"
+					:error="fieldError('storey_range', field.state.meta.errors)"
+					:model-value="field.state.value"
+					:placeholder="t('select_storey_range')"
+					:items="storeyOptions"
+					@update:model-value="field.handleChange"
+				/>
+			</FormField>
+
+			<FormField v-slot="{ field }" name="flat_model">
+				<FormSelect
+					:label="t('flat_model')"
+					label-for="input-flat_model"
+					:error="fieldError('flat_model', field.state.meta.errors)"
+					:model-value="field.state.value"
+					:placeholder="t('select_flat_model')"
+					:items="flatModelOptions"
+					@update:model-value="field.handleChange"
+				/>
+			</FormField>
+
+			<FormField v-slot="{ field }" name="floor_area_sqm">
+				<div class="grid gap-1.5">
+					<label
+						for="input-floor_area"
+						class="text-[11px] font-bold uppercase tracking-wider text-muted-foreground"
 					>
-						<span class="sr-only">{{ t('floor_area_unit') }}</span>
-						<span aria-hidden>m²</span>
-					</span>
+						{{ t('floor_area') }}
+					</label>
+					<div class="flex">
+						<Input
+							id="input-floor_area"
+							type="number"
+							inputmode="numeric"
+							enterkeyhint="done"
+							:min="20"
+							:max="300"
+							:step="1"
+							:model-value="Number.isNaN(field.state.value) ? '' : String(field.state.value)"
+							:placeholder="t('enter_floor_area')"
+							:error="fieldError('floor_area_sqm', field.state.meta.errors)"
+							class="relative rounded-r-none border-r-0 focus-visible:z-10"
+							@input="
+								field.handleChange(
+									($event.target as HTMLInputElement).value === ''
+										? Number.NaN
+										: Number(($event.target as HTMLInputElement).value)
+								)
+							"
+						/>
+						<span
+							class="inline-flex h-8 items-center rounded-r-sm border border-input bg-secondary px-3 text-xs font-semibold text-muted-foreground"
+						>
+							<span class="sr-only">{{ t('floor_area_unit') }}</span>
+							<span aria-hidden>m²</span>
+						</span>
+					</div>
+					<p
+						v-if="fieldError('floor_area_sqm', field.state.meta.errors)"
+						class="text-xs text-destructive"
+					>
+						{{ fieldError('floor_area_sqm', field.state.meta.errors) }}
+					</p>
 				</div>
-				<p v-if="fieldError('floor_area_sqm', floorAreaError)" class="text-xs text-destructive">
-					{{ fieldError('floor_area_sqm', floorAreaError) }}
-				</p>
-			</div>
+			</FormField>
 		</div>
 
-		<FormSelect
-			:label="t('lease_commence_date')"
-			label-for="input-lease_commence_date"
-			:error="fieldError('lease_commence_date', leaseCommenceDateError)"
-			:model-value="String(leaseCommenceDate)"
-			:placeholder="t('select_year')"
-			:items="leaseYearOptions"
-			@update:model-value="leaseCommenceDate = Number($event)"
-		/>
+		<FormField v-slot="{ field }" name="lease_commence_date">
+			<FormSelect
+				:label="t('lease_commence_date')"
+				label-for="input-lease_commence_date"
+				:error="fieldError('lease_commence_date', field.state.meta.errors)"
+				:model-value="String(field.state.value as number)"
+				:placeholder="t('select_year')"
+				:items="leaseYearOptions"
+				@update:model-value="field.handleChange(Number($event))"
+			/>
+		</FormField>
 
 		<div class="grid grid-cols-2 gap-2.5 max-sm:grid-cols-1">
 			<Button

--- a/app/components/prediction/PredictionForm.vue
+++ b/app/components/prediction/PredictionForm.vue
@@ -151,10 +151,10 @@ const leaseYearOptions = computed(() =>
 				:label="t('lease_commence_date')"
 				label-for="input-lease_commence_date"
 				:error="fieldError('lease_commence_date', field.state.meta.errors)"
-				:model-value="field.state.value ? String(field.state.value) : ''"
+				:model-value="field.state.value == null || Number.isNaN(field.state.value) ? '' : String(field.state.value)"
 				:placeholder="t('select_year')"
 				:items="leaseYearOptions"
-				@update:model-value="field.handleChange(Number($event))"
+				@update:model-value="field.handleChange($event ? Number($event) : NaN)"
 			/>
 		</FormField>
 

--- a/app/components/prediction/PredictionPage.vue
+++ b/app/components/prediction/PredictionPage.vue
@@ -13,30 +13,20 @@ import CardTitle from '~/components/ui/CardTitle.vue';
 import Skeleton from '~/components/ui/Skeleton.vue';
 import Tooltip from '~/components/ui/Tooltip.vue';
 import { FLAT_MODELS, ML_MODELS, TOWNS } from '~/utils/lists';
-import { getPredictionTheme } from '~/utils/prediction';
-import type { FieldUpdate } from '~/composables/usePredictionForm';
 
 const { t, locale, setLocale } = useI18n();
 
-const {
-	form,
-	fieldErrors,
-	validate,
-	updateField: applyFieldUpdate,
-	reset: resetFields
-} = usePredictionForm();
+const { form, validate, reset: resetFields } = usePredictionForm();
 const {
 	output,
 	trendData,
 	loading,
 	errorMessage,
 	summaryValues,
-	clearError,
 	reset: resetResults,
 	predict
 } = usePrediction();
 
-// VueUse owns the `dark` class on <html> and persists the choice to localStorage.
 const colorMode = useColorMode({
 	storageKey: 'theme',
 	initialValue: 'light',
@@ -45,7 +35,6 @@ const colorMode = useColorMode({
 
 const isHydrated = ref(false);
 
-const theme = computed(() => getPredictionTheme(colorMode.value === 'dark'));
 const darkMode = computed(() => colorMode.value === 'dark');
 const isZh = computed(() => locale.value === 'zh');
 
@@ -77,11 +66,6 @@ useHead(() => ({
 	}
 }));
 
-function updateField(payload: FieldUpdate) {
-	applyFieldUpdate(payload);
-	clearError();
-}
-
 function toggleTheme() {
 	colorMode.value = colorMode.value === 'dark' ? 'light' : 'dark';
 }
@@ -96,7 +80,7 @@ function resetForm() {
 }
 
 async function handleSubmit() {
-	if (!validate()) {
+	if (!(await validate())) {
 		return;
 	}
 
@@ -112,7 +96,6 @@ onMounted(() => {
 <template>
 	<main v-if="isHydrated" class="min-h-screen px-6 pb-10 pt-4 max-sm:px-3 max-sm:pb-6">
 		<div class="mx-auto max-w-7xl">
-			<!-- Sticky header — blurred background, no flash -->
 			<header
 				class="sticky top-0 z-20 -mx-6 mb-5 flex items-center justify-between gap-4 border-b border-border bg-background/90 px-6 py-3 backdrop-blur-sm max-sm:relative max-sm:mx-0 max-sm:flex-col max-sm:items-start max-sm:px-0"
 			>
@@ -154,13 +137,10 @@ onMounted(() => {
 				</div>
 			</header>
 
-			<!-- Two-column layout — stacks at 860px -->
 			<div
 				class="grid grid-cols-[minmax(0,0.92fr)_minmax(0,1.08fr)] items-start gap-4 max-[860px]:grid-cols-1"
 			>
-				<!-- Left column: intro + form -->
 				<div class="flex flex-col gap-4">
-					<!-- Intro card -->
 					<Card class="py-5">
 						<CardHeader class="px-5 pb-0">
 							<CardTitle
@@ -189,7 +169,6 @@ onMounted(() => {
 						</CardContent>
 					</Card>
 
-					<!-- Form card -->
 					<Card class="py-4">
 						<CardHeader class="px-5 pb-2">
 							<CardTitle class="text-sm text-primary normal-case">
@@ -198,36 +177,30 @@ onMounted(() => {
 						</CardHeader>
 						<CardContent class="px-5">
 							<PredictionForm
-								:form="form"
-								:field-errors="fieldErrors"
 								:loading="loading"
 								:error-message="errorMessage"
 								@submit="handleSubmit"
 								@reset="resetForm"
-								@update-field="updateField"
 							/>
 						</CardContent>
 					</Card>
 				</div>
 
-				<!-- Right column: results -->
 				<div>
 					<PredictionResults
 						:output="output"
 						:loading="loading"
 						:summary-values="summaryValues"
 						:trend-data="trendData"
-						:theme="theme"
+						:dark-mode="darkMode"
 					/>
 				</div>
 			</div>
 		</div>
 	</main>
 
-	<!-- Pre-hydration skeleton — shimmer placeholders sized to the real layout to prevent flash/CLS -->
 	<main v-else class="min-h-screen px-6 pb-10 pt-4" aria-busy="true">
 		<div class="mx-auto max-w-7xl">
-			<!-- Header skeleton — matches real header dimensions to prevent CLS -->
 			<div
 				class="sticky top-0 z-20 -mx-6 mb-5 flex items-center justify-between gap-4 border-b border-border bg-background/90 px-6 py-3 backdrop-blur-sm max-sm:relative max-sm:mx-0 max-sm:flex-col max-sm:items-start max-sm:px-0"
 			>

--- a/app/components/prediction/PredictionPage.vue
+++ b/app/components/prediction/PredictionPage.vue
@@ -16,7 +16,6 @@ import { FLAT_MODELS, ML_MODELS, TOWNS } from '~/utils/lists';
 
 const { t, locale, setLocale } = useI18n();
 
-const { form, validate, reset: resetFields } = usePredictionForm();
 const {
 	output,
 	trendData,
@@ -26,6 +25,10 @@ const {
 	reset: resetResults,
 	predict
 } = usePrediction();
+
+const { form, reset: resetFields } = usePredictionForm({
+	onSubmit: (values) => predict(values)
+});
 
 const colorMode = useColorMode({
 	storageKey: 'theme',
@@ -77,14 +80,6 @@ function setLanguage(language: 'en' | 'zh') {
 function resetForm() {
 	resetFields();
 	resetResults();
-}
-
-async function handleSubmit() {
-	if (!(await validate())) {
-		return;
-	}
-
-	await predict(form.value);
 }
 
 onMounted(() => {
@@ -177,9 +172,9 @@ onMounted(() => {
 						</CardHeader>
 						<CardContent class="px-5">
 							<PredictionForm
+								:form="form"
 								:loading="loading"
 								:error-message="errorMessage"
-								@submit="handleSubmit"
 								@reset="resetForm"
 							/>
 						</CardContent>

--- a/app/components/prediction/PredictionResults.vue
+++ b/app/components/prediction/PredictionResults.vue
@@ -8,16 +8,16 @@ import Separator from '~/components/ui/Separator.vue';
 import Skeleton from '~/components/ui/Skeleton.vue';
 import { cn } from '~/lib/utils';
 import { formatCurrency } from '~/utils/format';
-import type { PredictionTheme, SummaryValues, TrendPoint } from '~/utils/prediction';
+import type { SummaryValues, TrendPoint } from '~/utils/prediction';
 
-const { t } = useI18n();
+const { t, locale } = useI18n();
 
 const props = defineProps<{
 	output: number;
 	loading: boolean;
 	summaryValues: SummaryValues;
 	trendData: TrendPoint[];
-	theme: PredictionTheme;
+	darkMode: boolean;
 }>();
 
 const hasOutput = computed(() => props.output > 0);
@@ -45,7 +45,7 @@ function optionLabel(
 }
 
 function formatPrice(value: number) {
-	return formatCurrency(value);
+	return formatCurrency(value, locale.value);
 }
 
 const summaryItems = computed(() => [
@@ -70,7 +70,6 @@ const summaryItems = computed(() => [
 <template>
 	<section aria-labelledby="prediction-results-heading" :aria-busy="loading">
 		<div class="rounded-lg border border-border bg-card">
-			<!-- Header: title + price badge -->
 			<div class="flex flex-row items-start justify-between gap-4 px-5 py-4 max-sm:flex-col">
 				<div>
 					<h2
@@ -81,7 +80,6 @@ const summaryItems = computed(() => [
 					</h2>
 				</div>
 
-				<!-- Price badge -->
 				<div
 					:class="
 						cn(
@@ -110,12 +108,10 @@ const summaryItems = computed(() => [
 				</div>
 			</div>
 
-			<!-- Body -->
 			<div class="flex flex-col gap-4 px-5 pb-5">
 				<ResultsSkeleton v-if="showSkeleton" />
 				<template v-else>
 					<template v-if="hasOutput">
-						<!-- Summary tiles -->
 						<div class="grid grid-cols-3 gap-2 max-sm:grid-cols-1">
 							<div
 								v-for="item in summaryItems"
@@ -139,7 +135,6 @@ const summaryItems = computed(() => [
 
 						<Separator />
 
-						<!-- Chart section -->
 						<div>
 							<p
 								class="mb-0.5 text-[10px] font-bold uppercase tracking-wider text-muted-foreground"
@@ -150,7 +145,6 @@ const summaryItems = computed(() => [
 								{{ t('chart_story_title') }}
 							</h3>
 
-							<!-- Stats row -->
 							<div class="mb-3 grid grid-cols-3 gap-2 max-sm:grid-cols-1">
 								<div
 									class="rounded-sm border border-border bg-secondary/40 px-3 py-2 transition-all duration-200 hover:border-primary/20"
@@ -199,12 +193,11 @@ const summaryItems = computed(() => [
 								</div>
 							</div>
 
-							<!-- Chart -->
 							<div
 								class="min-h-[240px] overflow-hidden rounded-sm border border-border bg-secondary/20 p-2"
 							>
 								<ClientOnly>
-									<PriceTrendChart :data="trendData" :theme="theme" />
+									<PriceTrendChart :data="trendData" :dark-mode="darkMode" />
 									<template #fallback>
 										<div class="animate-shimmer min-h-[240px] w-full rounded-sm bg-muted" />
 									</template>
@@ -213,7 +206,6 @@ const summaryItems = computed(() => [
 						</div>
 					</template>
 
-					<!-- Empty state -->
 					<div
 						v-else
 						class="flex flex-col items-center justify-center gap-3 rounded-sm border border-dashed border-border bg-secondary/20 px-4 py-12 text-center"

--- a/app/components/prediction/PriceTrendChart.vue
+++ b/app/components/prediction/PriceTrendChart.vue
@@ -1,153 +1,70 @@
 <script setup lang="ts">
-import { computed, onBeforeUnmount, onMounted, ref } from 'vue';
-import {
-	CategoryScale,
-	Chart as ChartJS,
-	Filler,
-	LineElement,
-	LinearScale,
-	PointElement,
-	Tooltip,
-	type ChartData,
-	type ChartOptions
-} from 'chart.js';
-import { Line } from 'vue-chartjs';
+import { computed } from 'vue';
+import { use } from 'echarts/core';
+import { LineChart } from 'echarts/charts';
+import { GridComponent, TooltipComponent } from 'echarts/components';
+import { SVGRenderer } from 'echarts/renderers';
+import VChart from 'vue-echarts';
 
 import { formatCurrency } from '~/utils/format';
-import { formatCurrencyTick, normalizePrice, type PredictionTheme, type TrendPoint } from '~/utils/prediction';
+import { formatCurrencyTick, normalizePrice, type TrendPoint } from '~/utils/prediction';
 
-const { t } = useI18n();
+const { t, locale } = useI18n();
 
 const props = defineProps<{
 	data: TrendPoint[];
-	theme: PredictionTheme;
+	darkMode: boolean;
 }>();
 
-const isMobile = ref(false);
+use([SVGRenderer, LineChart, GridComponent, TooltipComponent]);
 
-function updateViewport() {
-	if (!import.meta.client) {
-		return;
-	}
+const chartTheme = computed(() => (props.darkMode ? 'dark' : undefined));
 
-	isMobile.value = window.innerWidth < 900;
-}
-
-onMounted(() => {
-	updateViewport();
-	window.addEventListener('resize', updateViewport);
-});
-
-onBeforeUnmount(() => {
-	if (import.meta.client) {
-		window.removeEventListener('resize', updateViewport);
-	}
-});
-
-ChartJS.register(
-	CategoryScale,
-	LinearScale,
-	PointElement,
-	LineElement,
-	Tooltip,
-	Filler
-);
-
-const chartData = computed<ChartData<'line'>>(() => ({
-	labels: props.data.map((entry) => entry.label),
-	datasets: [
+const chartOption = computed(() => ({
+	xAxis: {
+		type: 'category' as const,
+		data: props.data.map((entry) => entry.label),
+		axisLabel: {
+			interval: 'auto' as const
+		}
+	},
+	yAxis: {
+		type: 'value' as const,
+		axisLabel: {
+			formatter: (value: number) => formatCurrencyTick(value)
+		}
+	},
+	series: [
 		{
+			type: 'line' as const,
 			data: props.data.map((entry) => entry.value),
-			fill: true,
-			tension: 0.4,
-			borderWidth: 3,
-			pointRadius: 0,
-			pointHoverRadius: 4,
-			pointHoverBorderWidth: 2,
-			borderColor: props.theme.chartLine,
-			backgroundColor: (context) => {
-				const chart = context.chart;
-				const area = chart.chartArea;
-				if (!area) {
-					return `${props.theme.chartLine}26`;
-				}
-
-				const gradient = chart.ctx.createLinearGradient(0, area.top, 0, area.bottom);
-				gradient.addColorStop(0, `${props.theme.chartLine}66`);
-				gradient.addColorStop(0.65, `${props.theme.chartLine}1f`);
-				gradient.addColorStop(1, `${props.theme.chartLine}00`);
-				return gradient;
-			},
-			pointHoverBackgroundColor: props.theme.panelStrong,
-			pointHoverBorderColor: props.theme.chartLine
+			smooth: true,
+			areaStyle: {},
+			showSymbol: false
 		}
-	]
-}));
-
-const chartOptions = computed<ChartOptions<'line'>>(() => ({
-	responsive: true,
-	maintainAspectRatio: false,
-	interaction: {
-		mode: 'index',
-		intersect: false
+	],
+	tooltip: {
+		trigger: 'axis' as const,
+		valueFormatter: (value: number) => formatCurrency(normalizePrice(value), locale.value)
 	},
-	animation: {
-		duration: 600
-	},
-	plugins: {
-		legend: {
-			display: false
-		},
-		tooltip: {
-			displayColors: false,
-			backgroundColor: props.theme.panelStrong,
-			borderColor: props.theme.lineSoft,
-			borderWidth: 1,
-			padding: 12,
-			titleColor: props.theme.textMuted,
-			bodyColor: props.theme.text,
-			titleFont: { size: 11, weight: 'bold' },
-			bodyFont: { size: 13, weight: 'bold' },
-			callbacks: {
-				label: (context) => formatCurrency(normalizePrice(Number(context.raw)))
-			}
-		}
-	},
-	scales: {
-		x: {
-			grid: { display: false },
-			border: { display: false },
-			ticks: {
-				color: props.theme.textMuted,
-				maxRotation: 0,
-				autoSkipPadding: 18,
-				font: {
-					family: "'Source Sans 3', 'Segoe UI', sans-serif",
-					size: isMobile.value ? 11 : 12
-				}
-			}
-		},
-		y: {
-			grid: {
-				color: props.theme.chartGrid,
-				tickBorderDash: [3, 10]
-			},
-			border: { display: false },
-			ticks: {
-				color: props.theme.textMuted,
-				callback: (value) => formatCurrencyTick(Number(value)),
-				font: {
-					family: "'Source Sans 3', 'Segoe UI', sans-serif",
-					size: isMobile.value ? 11 : 12
-				}
-			}
-		}
+	grid: {
+		left: 12,
+		right: 12,
+		top: 16,
+		bottom: 8,
+		containLabel: true
 	}
 }));
 </script>
 
 <template>
 	<div class="prediction-chart-frame" role="img" :aria-label="t('price_trend_chart_aria')">
-		<Line :data="chartData" :options="chartOptions" />
+		<VChart
+			class="h-[240px] w-full"
+			:theme="chartTheme"
+			:option="chartOption"
+			:init-options="{ renderer: 'svg' }"
+			autoresize
+		/>
 	</div>
 </template>

--- a/app/components/prediction/PriceTrendChart.vue
+++ b/app/components/prediction/PriceTrendChart.vue
@@ -5,6 +5,7 @@ import { LineChart } from 'echarts/charts';
 import { GridComponent, TooltipComponent } from 'echarts/components';
 import { SVGRenderer } from 'echarts/renderers';
 import VChart from 'vue-echarts';
+import 'echarts/theme/dark.js';
 
 import { formatCurrency } from '~/utils/format';
 import { formatCurrencyTick, normalizePrice, type TrendPoint } from '~/utils/prediction';

--- a/app/components/prediction/PriceTrendChart.vue
+++ b/app/components/prediction/PriceTrendChart.vue
@@ -61,7 +61,7 @@ const chartOption = computed(() => ({
 <template>
 	<div class="prediction-chart-frame" role="img" :aria-label="t('price_trend_chart_aria')">
 		<VChart
-			class="h-[240px] w-full"
+			style="height: 240px; width: 100%"
 			:theme="chartTheme"
 			:option="chartOption"
 			:init-options="{ renderer: 'svg' }"

--- a/app/composables/usePrediction.ts
+++ b/app/composables/usePrediction.ts
@@ -1,5 +1,6 @@
 import { ref } from 'vue';
 import { FetchError } from 'ofetch';
+
 import {
 	defaultTrendData,
 	initialFormValues,
@@ -22,10 +23,6 @@ function summaryFrom(values: SummaryValues): SummaryValues {
 
 function extractErrorMessage(error: unknown, fallback: string): string {
 	if (error instanceof FetchError) {
-		// `error.data` is the parsed response body. For an H3/Nitro `createError`,
-		// that body is `{ statusCode, statusMessage, message, data?, stack? }`, so
-		// `data.statusMessage` is the server-authored message — prefer it, then
-		// fall back to `data.message`.
 		const data = error.data;
 
 		if (data && typeof data === 'object') {
@@ -38,8 +35,6 @@ function extractErrorMessage(error: unknown, fallback: string): string {
 				return record.message;
 			}
 
-			// Other backends nest the message under `error`: handle both
-			// `{ error: "..." }` and `{ error: { message: "..." } }` shapes.
 			const errorField = record.error;
 			if (typeof errorField === 'string' && errorField.trim()) {
 				return errorField;
@@ -52,14 +47,10 @@ function extractErrorMessage(error: unknown, fallback: string): string {
 			}
 		}
 
-		// Raw string body (e.g., a non-JSON error page).
 		if (typeof data === 'string' && data.trim()) {
 			return data;
 		}
 
-		// Last resort: `error.statusMessage` here is the HTTP reason phrase
-		// (status text on the FetchError itself), distinct from the body's
-		// `data.statusMessage` handled above.
 		if (typeof error.statusMessage === 'string' && error.statusMessage.trim()) {
 			return error.statusMessage;
 		}
@@ -85,8 +76,6 @@ export function usePrediction() {
 	const errorMessage = ref('');
 	const summaryValues = ref<SummaryValues>(summaryFrom(initialFormValues));
 
-	// Tracks the in-flight request so a rapid re-submit can supersede the
-	// previous one — guards against out-of-order responses clobbering state.
 	let activeController: AbortController | null = null;
 
 	function clearError() {
@@ -101,7 +90,6 @@ export function usePrediction() {
 	}
 
 	async function predict(values: FieldType) {
-		// Supersede any in-flight request so its response can't overwrite this one.
 		activeController?.abort();
 		const controller = new AbortController();
 		activeController = controller;
@@ -113,27 +101,10 @@ export function usePrediction() {
 		summaryValues.value = summaryFrom(values);
 
 		try {
-			// Numeric fields must be finite — `usePredictionForm.validate()` guarantees
-			// this before predict() runs. Bail out loudly rather than silently
-			// substituting defaults, which would produce a confident, wrong prediction.
-			if (!Number.isFinite(values.floor_area_sqm) || !Number.isFinite(values.lease_commence_date)) {
-				throw new Error(t('error_invalid_input'));
-			}
-
-			const floorAreaSqm = Math.max(20, Math.min(300, Math.round(values.floor_area_sqm)));
-			const leaseCommenceYear = values.lease_commence_date;
-
-			const data = await $fetch<ApiResponse>('/api/prices', {
+			const data = await $fetch<ApiResponse>('/api/predict', {
 				method: 'POST',
 				signal: controller.signal,
-				body: {
-					mlModel: values.ml_model,
-					town: values.town,
-					storeyRange: values.storey_range,
-					flatModel: values.flat_model,
-					floorAreaSqm,
-					leaseCommenceYear
-				}
+				body: values
 			});
 
 			if (!data || !Array.isArray(data.predictions)) {
@@ -148,7 +119,6 @@ export function usePrediction() {
 			trendData.value = serverData;
 			output.value = normalizePrice(serverData[serverData.length - 1]?.value ?? 0);
 		} catch (error) {
-			// A newer submit aborted this request; let that newer call own the state.
 			if (controller.signal.aborted) {
 				return;
 			}
@@ -157,7 +127,6 @@ export function usePrediction() {
 			output.value = 0;
 			errorMessage.value = extractErrorMessage(error, t('error_fetch'));
 		} finally {
-			// Only the latest request clears the loading flag and releases the controller.
 			if (activeController === controller) {
 				loading.value = false;
 				activeController = null;

--- a/app/composables/usePredictionForm.ts
+++ b/app/composables/usePredictionForm.ts
@@ -23,7 +23,6 @@ function createPredictionForm({ onSubmit }: UsePredictionFormOptions) {
 export type PredictionFormHandle = ReturnType<typeof createPredictionForm>;
 
 export function usePredictionForm(options: UsePredictionFormOptions) {
-	const formState = useState<FieldType>('prediction-form', () => ({ ...initialFormValues }));
 	const storedForm = useLocalStorage<FieldType>('form', { ...initialFormValues }, {
 		mergeDefaults: true
 	});
@@ -33,25 +32,20 @@ export function usePredictionForm(options: UsePredictionFormOptions) {
 
 	onMounted(() => {
 		const merged = { ...initialFormValues, ...storedForm.value };
-		formState.value = merged;
 		form.reset(merged);
 	});
 
 	watch(
 		formValues,
 		(next) => {
-			const snapshot = { ...next } as FieldType;
-			formState.value = snapshot;
-			storedForm.value = snapshot;
+			storedForm.value = { ...next } as FieldType;
 		},
 		{ deep: true }
 	);
 
 	function reset() {
-		const defaults = { ...initialFormValues };
 		form.reset();
-		formState.value = defaults;
-		storedForm.value = defaults;
+		storedForm.value = { ...initialFormValues };
 	}
 
 	return { form, reset };

--- a/app/composables/usePredictionForm.ts
+++ b/app/composables/usePredictionForm.ts
@@ -1,43 +1,44 @@
-import { computed, onMounted, watch } from 'vue';
-import { toTypedSchema } from '@vee-validate/zod';
-import { useForm } from 'vee-validate';
+import { onMounted, watch } from 'vue';
+import { useForm } from '@tanstack/vue-form';
 
 import { predictionFormSchema } from '#shared/predictionSchema';
-import { translatePredictionFieldError } from '~/utils/predictionValidation';
 import { initialFormValues, type FieldType } from '~/utils/prediction';
 
-export type FieldUpdate = {
-	[K in keyof FieldType]: { key: K; value: FieldType[K] };
-}[keyof FieldType];
+type UsePredictionFormOptions = {
+	onSubmit: (values: FieldType) => void | Promise<void>;
+};
 
-export function usePredictionForm() {
-	const { t } = useI18n();
+function createPredictionForm({ onSubmit }: UsePredictionFormOptions) {
+	return useForm({
+		defaultValues: { ...initialFormValues },
+		validators: {
+			onChange: predictionFormSchema
+		},
+		onSubmit: async ({ value }) => {
+			await onSubmit(value as FieldType);
+		}
+	});
+}
 
+export type PredictionFormHandle = ReturnType<typeof createPredictionForm>;
+
+export function usePredictionForm(options: UsePredictionFormOptions) {
 	const formState = useState<FieldType>('prediction-form', () => ({ ...initialFormValues }));
 	const storedForm = useLocalStorage<FieldType>('form', { ...initialFormValues }, {
 		mergeDefaults: true
 	});
 
-	const {
-		errors,
-		values,
-		setFieldValue,
-		resetForm: resetVeeForm,
-		setValues,
-		validate: validateForm
-	} = useForm({
-		validationSchema: toTypedSchema(predictionFormSchema),
-		initialValues: formState.value
-	});
+	const form = createPredictionForm(options);
+	const formValues = form.useStore((state) => state.values);
 
 	onMounted(() => {
 		const merged = { ...initialFormValues, ...storedForm.value };
 		formState.value = merged;
-		setValues(merged);
+		form.reset(merged);
 	});
 
 	watch(
-		values,
+		formValues,
 		(next) => {
 			const snapshot = { ...next } as FieldType;
 			formState.value = snapshot;
@@ -46,37 +47,12 @@ export function usePredictionForm() {
 		{ deep: true }
 	);
 
-	const form = computed(() => values as FieldType);
-
-	const fieldErrors = computed(() => {
-		const resolved = {} as Record<keyof FieldType, string>;
-		for (const key of Object.keys(initialFormValues) as Array<keyof FieldType>) {
-			resolved[key] = translatePredictionFieldError(key, errors.value[key], t);
-		}
-		return resolved;
-	});
-
-	async function validate() {
-		const result = await validateForm();
-		return result.valid;
-	}
-
-	function updateField(payload: FieldUpdate) {
-		setFieldValue(payload.key, payload.value, true);
-	}
-
 	function reset() {
 		const defaults = { ...initialFormValues };
-		resetVeeForm({ values: defaults });
+		form.reset(defaults);
 		formState.value = defaults;
 		storedForm.value = defaults;
 	}
 
-	return {
-		form,
-		fieldErrors,
-		validate,
-		updateField,
-		reset
-	};
+	return { form, reset };
 }

--- a/app/composables/usePredictionForm.ts
+++ b/app/composables/usePredictionForm.ts
@@ -1,5 +1,10 @@
-import { reactive } from 'vue';
-import { initialFormValues, MAX_LEASE_COMMENCE_YEAR, type FieldType } from '~/utils/prediction';
+import { computed, onMounted, watch } from 'vue';
+import { toTypedSchema } from '@vee-validate/zod';
+import { useForm } from 'vee-validate';
+
+import { predictionFormSchema } from '#shared/predictionSchema';
+import { translatePredictionFieldError } from '~/utils/predictionValidation';
+import { initialFormValues, type FieldType } from '~/utils/prediction';
 
 export type FieldUpdate = {
 	[K in keyof FieldType]: { key: K; value: FieldType[K] };
@@ -8,78 +13,70 @@ export type FieldUpdate = {
 export function usePredictionForm() {
 	const { t } = useI18n();
 
-	// Persisted to localStorage; `mergeDefaults` reconciles older/partial stored
-	// shapes against the current field set. SSR-safe: returns defaults on the
-	// server and hydrates from storage on the client.
-	const form = useLocalStorage<FieldType>('form', { ...initialFormValues }, {
+	const formState = useState<FieldType>('prediction-form', () => ({ ...initialFormValues }));
+	const storedForm = useLocalStorage<FieldType>('form', { ...initialFormValues }, {
 		mergeDefaults: true
 	});
-	const fieldErrors = reactive<Record<keyof FieldType, string>>({
-		ml_model: '',
-		town: '',
-		storey_range: '',
-		flat_model: '',
-		floor_area_sqm: '',
-		lease_commence_date: ''
+
+	const {
+		errors,
+		values,
+		setFieldValue,
+		resetForm: resetVeeForm,
+		setValues,
+		validate: validateForm
+	} = useForm({
+		validationSchema: toTypedSchema(predictionFormSchema),
+		initialValues: formState.value
 	});
 
-	function clearErrors() {
-		for (const key of Object.keys(fieldErrors) as Array<keyof FieldType>) {
-			fieldErrors[key] = '';
+	onMounted(() => {
+		const merged = { ...initialFormValues, ...storedForm.value };
+		formState.value = merged;
+		setValues(merged);
+	});
+
+	watch(
+		values,
+		(next) => {
+			const snapshot = { ...next } as FieldType;
+			formState.value = snapshot;
+			storedForm.value = snapshot;
+		},
+		{ deep: true }
+	);
+
+	const form = computed(() => values as FieldType);
+
+	const fieldErrors = computed(() => {
+		const resolved = {} as Record<keyof FieldType, string>;
+		for (const key of Object.keys(initialFormValues) as Array<keyof FieldType>) {
+			resolved[key] = translatePredictionFieldError(key, errors.value[key], t);
 		}
-	}
+		return resolved;
+	});
 
-	function validate() {
-		clearErrors();
-		const values = form.value;
-
-		if (!values.ml_model) {
-			fieldErrors.ml_model = t('missing_ml_model');
-		}
-
-		if (!values.town) {
-			fieldErrors.town = t('missing_town');
-		}
-
-		if (!values.storey_range) {
-			fieldErrors.storey_range = t('missing_storey_range');
-		}
-
-		if (!values.flat_model) {
-			fieldErrors.flat_model = t('missing_flat_model');
-		}
-
-		if (!Number.isFinite(values.floor_area_sqm)) {
-			fieldErrors.floor_area_sqm = t('missing_floor_area');
-		} else if (values.floor_area_sqm < 20 || values.floor_area_sqm > 300) {
-			fieldErrors.floor_area_sqm = t('floor_area_range');
-		}
-
-		if (!Number.isFinite(values.lease_commence_date)) {
-			fieldErrors.lease_commence_date = t('missing_lease_commence_date');
-		} else if (
-			values.lease_commence_date < 1960 ||
-			values.lease_commence_date > MAX_LEASE_COMMENCE_YEAR
-		) {
-			fieldErrors.lease_commence_date = t('lease_commence_date_range');
-		}
-
-		return !Object.values(fieldErrors).some(Boolean);
+	async function validate() {
+		const result = await validateForm();
+		return result.valid;
 	}
 
 	function updateField(payload: FieldUpdate) {
-		form.value = {
-			...form.value,
-			[payload.key]: payload.value
-		};
-
-		fieldErrors[payload.key] = '';
+		setFieldValue(payload.key, payload.value, true);
 	}
 
 	function reset() {
-		form.value = { ...initialFormValues };
-		clearErrors();
+		const defaults = { ...initialFormValues };
+		resetVeeForm({ values: defaults });
+		formState.value = defaults;
+		storedForm.value = defaults;
 	}
 
-	return { form, fieldErrors, clearErrors, validate, updateField, reset };
+	return {
+		form,
+		fieldErrors,
+		validate,
+		updateField,
+		reset
+	};
 }

--- a/app/composables/usePredictionForm.ts
+++ b/app/composables/usePredictionForm.ts
@@ -49,7 +49,7 @@ export function usePredictionForm(options: UsePredictionFormOptions) {
 
 	function reset() {
 		const defaults = { ...initialFormValues };
-		form.reset(defaults);
+		form.reset();
 		formState.value = defaults;
 		storedForm.value = defaults;
 	}

--- a/app/utils/format.ts
+++ b/app/utils/format.ts
@@ -1,6 +1,17 @@
-export function formatCurrency(value: number) {
+const LOCALE_BY_CODE: Record<string, string> = {
+	en: 'en-SG',
+	zh: 'zh-Hans-SG'
+};
+
+export function resolveNumberLocale(localeCode: string) {
+	return LOCALE_BY_CODE[localeCode] ?? 'en-SG';
+}
+
+export function formatCurrency(value: number, localeCode = 'en') {
+	const locale = resolveNumberLocale(localeCode);
+
 	try {
-		return new Intl.NumberFormat('en-SG', {
+		return new Intl.NumberFormat(locale, {
 			style: 'currency',
 			currency: 'SGD',
 			maximumFractionDigits: 0

--- a/app/utils/predictionValidation.ts
+++ b/app/utils/predictionValidation.ts
@@ -1,0 +1,36 @@
+import type { FieldType } from '~/utils/prediction';
+
+type TranslateFn = (key: string) => string;
+
+export function translatePredictionFieldError(
+	field: keyof FieldType,
+	message: string | undefined,
+	t: TranslateFn
+): string {
+	if (!message) {
+		return '';
+	}
+
+	switch (field) {
+		case 'ml_model':
+			return t('missing_ml_model');
+		case 'town':
+			return t('missing_town');
+		case 'storey_range':
+			return t('missing_storey_range');
+		case 'flat_model':
+			return t('missing_flat_model');
+		case 'floor_area_sqm':
+			if (message === 'invalid_floor_area') {
+				return t('missing_floor_area');
+			}
+			return t('floor_area_range');
+		case 'lease_commence_date':
+			if (message === 'invalid_lease_commence_date') {
+				return t('missing_lease_commence_date');
+			}
+			return t('lease_commence_date_range');
+		default:
+			return message;
+	}
+}

--- a/app/utils/predictionValidation.ts
+++ b/app/utils/predictionValidation.ts
@@ -2,11 +2,27 @@ import type { FieldType } from '~/utils/prediction';
 
 type TranslateFn = (key: string) => string;
 
+function errorMessage(error: unknown): string | undefined {
+	if (typeof error === 'string') {
+		return error;
+	}
+
+	if (error && typeof error === 'object' && 'message' in error) {
+		const message = (error as { message?: unknown }).message;
+		if (typeof message === 'string') {
+			return message;
+		}
+	}
+
+	return undefined;
+}
+
 export function translatePredictionFieldError(
 	field: keyof FieldType,
-	message: string | undefined,
+	errors: unknown[] | undefined,
 	t: TranslateFn
 ): string {
+	const message = errorMessage(errors?.[0]);
 	if (!message) {
 		return '';
 	}

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
 				"@lucide/vue": "^1.16.0",
 				"@nuxtjs/i18n": "^10.4.0",
 				"@tailwindcss/vite": "^4.3.0",
-				"@vee-validate/zod": "^4.15.1",
+				"@tanstack/vue-form": "^1.33.0",
 				"@vueuse/nuxt": "^14.3.0",
 				"class-variance-authority": "^0.7.1",
 				"clsx": "^2.1.1",
@@ -17,7 +17,6 @@
 				"reka-ui": "^2.9.8",
 				"tailwind-merge": "^3.6.0",
 				"tailwindcss": "^4.3.0",
-				"vee-validate": "^4.15.1",
 				"vue-echarts": "^8.0.1",
 				"zod": "^3.25.76"
 			},
@@ -6650,6 +6649,60 @@
 				"vite": "^5.2.0 || ^6 || ^7 || ^8"
 			}
 		},
+		"node_modules/@tanstack/devtools-event-client": {
+			"version": "0.4.3",
+			"resolved": "https://registry.npmjs.org/@tanstack/devtools-event-client/-/devtools-event-client-0.4.3.tgz",
+			"integrity": "sha512-OZI6QyULw0FI0wjgmeYzCIfbgPsOEzwJtCpa69XrfLMtNXLGnz3d/dIabk7frg0TmHo+Ah49w5I4KC7Tufwsvw==",
+			"license": "MIT",
+			"bin": {
+				"intent": "bin/intent.js"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/tannerlinsley"
+			}
+		},
+		"node_modules/@tanstack/form-core": {
+			"version": "1.33.0",
+			"resolved": "https://registry.npmjs.org/@tanstack/form-core/-/form-core-1.33.0.tgz",
+			"integrity": "sha512-AV4Pw9Dk4orFsuPBcDssfWMJFs+yMYBae7zZ4oTqrCf4ftNGQKxvrQRZeqKHG6A4TkiLeSvf2kzIjcVkrW7E6w==",
+			"license": "MIT",
+			"dependencies": {
+				"@tanstack/devtools-event-client": "^0.4.1",
+				"@tanstack/pacer-lite": "^0.1.1",
+				"@tanstack/store": "^0.11.0"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/tannerlinsley"
+			}
+		},
+		"node_modules/@tanstack/pacer-lite": {
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/@tanstack/pacer-lite/-/pacer-lite-0.1.1.tgz",
+			"integrity": "sha512-y/xtNPNt/YeyoVxE/JCx+T7yjEzpezmbb+toK8DDD1P4m7Kzs5YR956+7OKexG3f8aXgC3rLZl7b1V+yNUSy5w==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/tannerlinsley"
+			}
+		},
+		"node_modules/@tanstack/store": {
+			"version": "0.11.0",
+			"resolved": "https://registry.npmjs.org/@tanstack/store/-/store-0.11.0.tgz",
+			"integrity": "sha512-WlzzCt3xi0G6pCAJu1U+2jiECwabETDpQDi3hfkFZvJii9AuZqEKbOiVarX1/bWhTNjU486yQtJCCasi/0q+Cw==",
+			"license": "MIT",
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/tannerlinsley"
+			}
+		},
 		"node_modules/@tanstack/virtual-core": {
 			"version": "3.15.0",
 			"resolved": "https://registry.npmjs.org/@tanstack/virtual-core/-/virtual-core-3.15.0.tgz",
@@ -6658,6 +6711,72 @@
 			"funding": {
 				"type": "github",
 				"url": "https://github.com/sponsors/tannerlinsley"
+			}
+		},
+		"node_modules/@tanstack/vue-form": {
+			"version": "1.33.0",
+			"resolved": "https://registry.npmjs.org/@tanstack/vue-form/-/vue-form-1.33.0.tgz",
+			"integrity": "sha512-ZdVDo4W2ohL27bCjsuNy/eQ8PHm9mOzCFNfI7d6GfhS5KHqehZ8TiR/y1eRJR/c1y3nucgSi6RfY6iLHBMVhAQ==",
+			"license": "MIT",
+			"dependencies": {
+				"@tanstack/form-core": "1.33.0",
+				"@tanstack/vue-store": "^0.11.0"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/tannerlinsley"
+			},
+			"peerDependencies": {
+				"vue": "^3.4.0"
+			}
+		},
+		"node_modules/@tanstack/vue-store": {
+			"version": "0.11.0",
+			"resolved": "https://registry.npmjs.org/@tanstack/vue-store/-/vue-store-0.11.0.tgz",
+			"integrity": "sha512-w1lE4D7oo6nIUhTQvL/RoTgcvoYJw+KvttWPNJd/Xu+MvNxMnjxFF/LgFp9vwmbNbiGhGCg3ZoPJptwjrfwNYw==",
+			"license": "MIT",
+			"dependencies": {
+				"@tanstack/store": "0.11.0",
+				"vue-demi": "^0.14.10"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/tannerlinsley"
+			},
+			"peerDependencies": {
+				"@vue/composition-api": "^1.2.1",
+				"vue": "^2.5.0 || ^3.0.0"
+			},
+			"peerDependenciesMeta": {
+				"@vue/composition-api": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@tanstack/vue-store/node_modules/vue-demi": {
+			"version": "0.14.10",
+			"resolved": "https://registry.npmjs.org/vue-demi/-/vue-demi-0.14.10.tgz",
+			"integrity": "sha512-nMZBOwuzabUO0nLgIcc6rycZEebF6eeUfaiQx9+WSk8e29IbLvPU9feI6tqW4kTo3hvoYAJkMh8n8D0fuISphg==",
+			"hasInstallScript": true,
+			"license": "MIT",
+			"bin": {
+				"vue-demi-fix": "bin/vue-demi-fix.js",
+				"vue-demi-switch": "bin/vue-demi-switch.js"
+			},
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/antfu"
+			},
+			"peerDependencies": {
+				"@vue/composition-api": "^1.0.0-rc.1",
+				"vue": "^3.0.0-0 || ^2.6.0"
+			},
+			"peerDependenciesMeta": {
+				"@vue/composition-api": {
+					"optional": true
+				}
 			}
 		},
 		"node_modules/@tanstack/vue-virtual": {
@@ -7270,31 +7389,6 @@
 			"os": [
 				"win32"
 			]
-		},
-		"node_modules/@vee-validate/zod": {
-			"version": "4.15.1",
-			"resolved": "https://registry.npmjs.org/@vee-validate/zod/-/zod-4.15.1.tgz",
-			"integrity": "sha512-329Z4TDBE5Vx0FdbA8S4eR9iGCFFUNGbxjpQ20ff5b5wGueScjocUIx9JHPa79LTG06RnlUR4XogQsjN4tecKA==",
-			"license": "MIT",
-			"dependencies": {
-				"type-fest": "^4.8.3",
-				"vee-validate": "4.15.1"
-			},
-			"peerDependencies": {
-				"zod": "^3.24.0"
-			}
-		},
-		"node_modules/@vee-validate/zod/node_modules/type-fest": {
-			"version": "4.41.0",
-			"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.41.0.tgz",
-			"integrity": "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==",
-			"license": "(MIT OR CC0-1.0)",
-			"engines": {
-				"node": ">=16"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
 		},
 		"node_modules/@vercel/nft": {
 			"version": "1.5.0",
@@ -8704,21 +8798,6 @@
 			"resolved": "https://registry.npmjs.org/cookie-es/-/cookie-es-1.2.3.tgz",
 			"integrity": "sha512-lXVyvUvrNXblMqzIRrxHb57UUVmqsSWlxqt3XIjCkUP0wDAf6uicO6KMbEgYrMNtEvWgWHwe42CKxPu9MYAnWw==",
 			"license": "MIT"
-		},
-		"node_modules/copy-anything": {
-			"version": "4.0.5",
-			"resolved": "https://registry.npmjs.org/copy-anything/-/copy-anything-4.0.5.tgz",
-			"integrity": "sha512-7Vv6asjS4gMOuILabD3l739tsaxFQmC+a7pLZm02zyvs8p977bL3zEgq3yDk5rn9B0PbYgIv++jmHcuUab4RhA==",
-			"license": "MIT",
-			"dependencies": {
-				"is-what": "^5.2.0"
-			},
-			"engines": {
-				"node": ">=18"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/mesqueeb"
-			}
 		},
 		"node_modules/core-js-compat": {
 			"version": "3.49.0",
@@ -10963,18 +11042,6 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
-		"node_modules/is-what": {
-			"version": "5.5.0",
-			"resolved": "https://registry.npmjs.org/is-what/-/is-what-5.5.0.tgz",
-			"integrity": "sha512-oG7cgbmg5kLYae2N5IVd3jm2s+vldjxJzK1pcu9LfpGuQ93MQSzo0okvRna+7y5ifrD+20FE8FvjusyGaz14fw==",
-			"license": "MIT",
-			"engines": {
-				"node": ">=18"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/mesqueeb"
-			}
-		},
 		"node_modules/is-wsl": {
 			"version": "3.1.1",
 			"resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-3.1.1.tgz",
@@ -11893,12 +11960,6 @@
 			"engines": {
 				"node": ">= 18"
 			}
-		},
-		"node_modules/mitt": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/mitt/-/mitt-3.0.1.tgz",
-			"integrity": "sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw==",
-			"license": "MIT"
 		},
 		"node_modules/mlly": {
 			"version": "1.8.2",
@@ -14223,12 +14284,6 @@
 				"node": ">=0.10.0"
 			}
 		},
-		"node_modules/rfdc": {
-			"version": "1.4.1",
-			"resolved": "https://registry.npmjs.org/rfdc/-/rfdc-1.4.1.tgz",
-			"integrity": "sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==",
-			"license": "MIT"
-		},
 		"node_modules/rollup": {
 			"version": "4.60.4",
 			"resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.4.tgz",
@@ -14760,15 +14815,6 @@
 			"dev": true,
 			"license": "CC0-1.0"
 		},
-		"node_modules/speakingurl": {
-			"version": "14.0.1",
-			"resolved": "https://registry.npmjs.org/speakingurl/-/speakingurl-14.0.1.tgz",
-			"integrity": "sha512-1POYv7uv2gXoyGFpBCmpDVSNV74IfsWlDW216UPjbWufNf+bSU6GdbDsxdcxtfwb4xlI3yxzOTKClUosxARYrQ==",
-			"license": "BSD-3-Clause",
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
 		"node_modules/srvx": {
 			"version": "0.11.16",
 			"resolved": "https://registry.npmjs.org/srvx/-/srvx-0.11.16.tgz",
@@ -14991,18 +15037,6 @@
 			},
 			"peerDependencies": {
 				"postcss": "^8.5.14"
-			}
-		},
-		"node_modules/superjson": {
-			"version": "2.2.6",
-			"resolved": "https://registry.npmjs.org/superjson/-/superjson-2.2.6.tgz",
-			"integrity": "sha512-H+ue8Zo4vJmV2nRjpx86P35lzwDT3nItnIsocgumgr0hHMQ+ZGq5vrERg9kJBo5AWGmxZDhzDo+WVIJqkB0cGA==",
-			"license": "MIT",
-			"dependencies": {
-				"copy-anything": "^4"
-			},
-			"engines": {
-				"node": ">=16"
 			}
 		},
 		"node_modules/supports-preserve-symlinks-flag": {
@@ -15802,85 +15836,6 @@
 			"resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
 			"integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
 			"license": "MIT"
-		},
-		"node_modules/vee-validate": {
-			"version": "4.15.1",
-			"resolved": "https://registry.npmjs.org/vee-validate/-/vee-validate-4.15.1.tgz",
-			"integrity": "sha512-DkFsiTwEKau8VIxyZBGdO6tOudD+QoUBPuHj3e6QFqmbfCRj1ArmYWue9lEp6jLSWBIw4XPlDLjFIZNLdRAMSg==",
-			"license": "MIT",
-			"dependencies": {
-				"@vue/devtools-api": "^7.5.2",
-				"type-fest": "^4.8.3"
-			},
-			"peerDependencies": {
-				"vue": "^3.4.26"
-			}
-		},
-		"node_modules/vee-validate/node_modules/@vue/devtools-api": {
-			"version": "7.7.9",
-			"resolved": "https://registry.npmjs.org/@vue/devtools-api/-/devtools-api-7.7.9.tgz",
-			"integrity": "sha512-kIE8wvwlcZ6TJTbNeU2HQNtaxLx3a84aotTITUuL/4bzfPxzajGBOoqjMhwZJ8L9qFYDU/lAYMEEm11dnZOD6g==",
-			"license": "MIT",
-			"dependencies": {
-				"@vue/devtools-kit": "^7.7.9"
-			}
-		},
-		"node_modules/vee-validate/node_modules/@vue/devtools-kit": {
-			"version": "7.7.9",
-			"resolved": "https://registry.npmjs.org/@vue/devtools-kit/-/devtools-kit-7.7.9.tgz",
-			"integrity": "sha512-PyQ6odHSgiDVd4hnTP+aDk2X4gl2HmLDfiyEnn3/oV+ckFDuswRs4IbBT7vacMuGdwY/XemxBoh302ctbsptuA==",
-			"license": "MIT",
-			"dependencies": {
-				"@vue/devtools-shared": "^7.7.9",
-				"birpc": "^2.3.0",
-				"hookable": "^5.5.3",
-				"mitt": "^3.0.1",
-				"perfect-debounce": "^1.0.0",
-				"speakingurl": "^14.0.1",
-				"superjson": "^2.2.2"
-			}
-		},
-		"node_modules/vee-validate/node_modules/@vue/devtools-shared": {
-			"version": "7.7.9",
-			"resolved": "https://registry.npmjs.org/@vue/devtools-shared/-/devtools-shared-7.7.9.tgz",
-			"integrity": "sha512-iWAb0v2WYf0QWmxCGy0seZNDPdO3Sp5+u78ORnyeonS6MT4PC7VPrryX2BpMJrwlDeaZ6BD4vP4XKjK0SZqaeA==",
-			"license": "MIT",
-			"dependencies": {
-				"rfdc": "^1.4.1"
-			}
-		},
-		"node_modules/vee-validate/node_modules/birpc": {
-			"version": "2.9.0",
-			"resolved": "https://registry.npmjs.org/birpc/-/birpc-2.9.0.tgz",
-			"integrity": "sha512-KrayHS5pBi69Xi9JmvoqrIgYGDkD6mcSe/i6YKi3w5kekCLzrX4+nawcXqrj2tIp50Kw/mT/s3p+GVK0A0sKxw==",
-			"license": "MIT",
-			"funding": {
-				"url": "https://github.com/sponsors/antfu"
-			}
-		},
-		"node_modules/vee-validate/node_modules/hookable": {
-			"version": "5.5.3",
-			"resolved": "https://registry.npmjs.org/hookable/-/hookable-5.5.3.tgz",
-			"integrity": "sha512-Yc+BQe8SvoXH1643Qez1zqLRmbA5rCL+sSmk6TVos0LWVfNIB7PGncdlId77WzLGSIB5KaWgTaNTs2lNVEI6VQ==",
-			"license": "MIT"
-		},
-		"node_modules/vee-validate/node_modules/perfect-debounce": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/perfect-debounce/-/perfect-debounce-1.0.0.tgz",
-			"integrity": "sha512-xCy9V055GLEqoFaHoC1SoLIaLmWctgCUaBaWxDZ7/Zx4CTyX7cJQLJOok/orfjZAh9kEYpjJa4d0KcJmCbctZA==",
-			"license": "MIT"
-		},
-		"node_modules/vee-validate/node_modules/type-fest": {
-			"version": "4.41.0",
-			"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.41.0.tgz",
-			"integrity": "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==",
-			"license": "(MIT OR CC0-1.0)",
-			"engines": {
-				"node": ">=16"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
 		},
 		"node_modules/vite": {
 			"version": "7.3.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-	"name": "prediction-tool-vue",
+	"name": "workspace",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
@@ -9,14 +9,17 @@
 				"@lucide/vue": "^1.16.0",
 				"@nuxtjs/i18n": "^10.4.0",
 				"@tailwindcss/vite": "^4.3.0",
+				"@vee-validate/zod": "^4.15.1",
 				"@vueuse/nuxt": "^14.3.0",
-				"chart.js": "^4.5.1",
 				"class-variance-authority": "^0.7.1",
 				"clsx": "^2.1.1",
+				"echarts": "^6.1.0",
 				"reka-ui": "^2.9.8",
 				"tailwind-merge": "^3.6.0",
 				"tailwindcss": "^4.3.0",
-				"vue-chartjs": "^5.3.2"
+				"vee-validate": "^4.15.1",
+				"vue-echarts": "^8.0.1",
+				"zod": "^3.25.76"
 			},
 			"devDependencies": {
 				"@cloudflare/workers-types": "^4.20260527.1",
@@ -2853,12 +2856,6 @@
 			"engines": {
 				"node": ">=12"
 			}
-		},
-		"node_modules/@kurkle/color": {
-			"version": "0.3.4",
-			"resolved": "https://registry.npmjs.org/@kurkle/color/-/color-0.3.4.tgz",
-			"integrity": "sha512-M5UknZPHRu3DEDWoipU6sE8PdkZ6Z/S+v4dD+Ke8IaNlpdSQah50lz1KtcFBa2vsdOnwbbnxJwVM4wty6udA5w==",
-			"license": "MIT"
 		},
 		"node_modules/@kwsites/file-exists": {
 			"version": "1.1.1",
@@ -7274,6 +7271,31 @@
 				"win32"
 			]
 		},
+		"node_modules/@vee-validate/zod": {
+			"version": "4.15.1",
+			"resolved": "https://registry.npmjs.org/@vee-validate/zod/-/zod-4.15.1.tgz",
+			"integrity": "sha512-329Z4TDBE5Vx0FdbA8S4eR9iGCFFUNGbxjpQ20ff5b5wGueScjocUIx9JHPa79LTG06RnlUR4XogQsjN4tecKA==",
+			"license": "MIT",
+			"dependencies": {
+				"type-fest": "^4.8.3",
+				"vee-validate": "4.15.1"
+			},
+			"peerDependencies": {
+				"zod": "^3.24.0"
+			}
+		},
+		"node_modules/@vee-validate/zod/node_modules/type-fest": {
+			"version": "4.41.0",
+			"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.41.0.tgz",
+			"integrity": "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==",
+			"license": "(MIT OR CC0-1.0)",
+			"engines": {
+				"node": ">=16"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
 		"node_modules/@vercel/nft": {
 			"version": "1.5.0",
 			"resolved": "https://registry.npmjs.org/@vercel/nft/-/nft-1.5.0.tgz",
@@ -8452,18 +8474,6 @@
 			"dev": true,
 			"license": "MIT"
 		},
-		"node_modules/chart.js": {
-			"version": "4.5.1",
-			"resolved": "https://registry.npmjs.org/chart.js/-/chart.js-4.5.1.tgz",
-			"integrity": "sha512-GIjfiT9dbmHRiYi6Nl2yFCq7kkwdkp1W/lp2J99rX0yo9tgJGn3lKQATztIjb5tVtevcBtIdICNWqlq5+E8/Pw==",
-			"license": "MIT",
-			"dependencies": {
-				"@kurkle/color": "^0.3.0"
-			},
-			"engines": {
-				"pnpm": ">=8"
-			}
-		},
 		"node_modules/chokidar": {
 			"version": "5.0.0",
 			"resolved": "https://registry.npmjs.org/chokidar/-/chokidar-5.0.0.tgz",
@@ -8694,6 +8704,21 @@
 			"resolved": "https://registry.npmjs.org/cookie-es/-/cookie-es-1.2.3.tgz",
 			"integrity": "sha512-lXVyvUvrNXblMqzIRrxHb57UUVmqsSWlxqt3XIjCkUP0wDAf6uicO6KMbEgYrMNtEvWgWHwe42CKxPu9MYAnWw==",
 			"license": "MIT"
+		},
+		"node_modules/copy-anything": {
+			"version": "4.0.5",
+			"resolved": "https://registry.npmjs.org/copy-anything/-/copy-anything-4.0.5.tgz",
+			"integrity": "sha512-7Vv6asjS4gMOuILabD3l739tsaxFQmC+a7pLZm02zyvs8p977bL3zEgq3yDk5rn9B0PbYgIv++jmHcuUab4RhA==",
+			"license": "MIT",
+			"dependencies": {
+				"is-what": "^5.2.0"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/mesqueeb"
+			}
 		},
 		"node_modules/core-js-compat": {
 			"version": "3.49.0",
@@ -9214,6 +9239,22 @@
 			"resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
 			"integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
 			"license": "MIT"
+		},
+		"node_modules/echarts": {
+			"version": "6.1.0",
+			"resolved": "https://registry.npmjs.org/echarts/-/echarts-6.1.0.tgz",
+			"integrity": "sha512-q0yaFPggC9FUdsWH4blavRWFmxdrIodbkoKNAjJudAI6CA9gNPxHtV2RcZNEepZVlk4yvBYkOkbk6HIVpIyHZA==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"tslib": "2.3.0",
+				"zrender": "6.1.0"
+			}
+		},
+		"node_modules/echarts/node_modules/tslib": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.0.tgz",
+			"integrity": "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg==",
+			"license": "0BSD"
 		},
 		"node_modules/ee-first": {
 			"version": "1.1.1",
@@ -10922,6 +10963,18 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
+		"node_modules/is-what": {
+			"version": "5.5.0",
+			"resolved": "https://registry.npmjs.org/is-what/-/is-what-5.5.0.tgz",
+			"integrity": "sha512-oG7cgbmg5kLYae2N5IVd3jm2s+vldjxJzK1pcu9LfpGuQ93MQSzo0okvRna+7y5ifrD+20FE8FvjusyGaz14fw==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/mesqueeb"
+			}
+		},
 		"node_modules/is-wsl": {
 			"version": "3.1.1",
 			"resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-3.1.1.tgz",
@@ -11840,6 +11893,12 @@
 			"engines": {
 				"node": ">= 18"
 			}
+		},
+		"node_modules/mitt": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/mitt/-/mitt-3.0.1.tgz",
+			"integrity": "sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw==",
+			"license": "MIT"
 		},
 		"node_modules/mlly": {
 			"version": "1.8.2",
@@ -14164,6 +14223,12 @@
 				"node": ">=0.10.0"
 			}
 		},
+		"node_modules/rfdc": {
+			"version": "1.4.1",
+			"resolved": "https://registry.npmjs.org/rfdc/-/rfdc-1.4.1.tgz",
+			"integrity": "sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==",
+			"license": "MIT"
+		},
 		"node_modules/rollup": {
 			"version": "4.60.4",
 			"resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.4.tgz",
@@ -14695,6 +14760,15 @@
 			"dev": true,
 			"license": "CC0-1.0"
 		},
+		"node_modules/speakingurl": {
+			"version": "14.0.1",
+			"resolved": "https://registry.npmjs.org/speakingurl/-/speakingurl-14.0.1.tgz",
+			"integrity": "sha512-1POYv7uv2gXoyGFpBCmpDVSNV74IfsWlDW216UPjbWufNf+bSU6GdbDsxdcxtfwb4xlI3yxzOTKClUosxARYrQ==",
+			"license": "BSD-3-Clause",
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
 		"node_modules/srvx": {
 			"version": "0.11.16",
 			"resolved": "https://registry.npmjs.org/srvx/-/srvx-0.11.16.tgz",
@@ -14917,6 +14991,18 @@
 			},
 			"peerDependencies": {
 				"postcss": "^8.5.14"
+			}
+		},
+		"node_modules/superjson": {
+			"version": "2.2.6",
+			"resolved": "https://registry.npmjs.org/superjson/-/superjson-2.2.6.tgz",
+			"integrity": "sha512-H+ue8Zo4vJmV2nRjpx86P35lzwDT3nItnIsocgumgr0hHMQ+ZGq5vrERg9kJBo5AWGmxZDhzDo+WVIJqkB0cGA==",
+			"license": "MIT",
+			"dependencies": {
+				"copy-anything": "^4"
+			},
+			"engines": {
+				"node": ">=16"
 			}
 		},
 		"node_modules/supports-preserve-symlinks-flag": {
@@ -15717,6 +15803,85 @@
 			"integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
 			"license": "MIT"
 		},
+		"node_modules/vee-validate": {
+			"version": "4.15.1",
+			"resolved": "https://registry.npmjs.org/vee-validate/-/vee-validate-4.15.1.tgz",
+			"integrity": "sha512-DkFsiTwEKau8VIxyZBGdO6tOudD+QoUBPuHj3e6QFqmbfCRj1ArmYWue9lEp6jLSWBIw4XPlDLjFIZNLdRAMSg==",
+			"license": "MIT",
+			"dependencies": {
+				"@vue/devtools-api": "^7.5.2",
+				"type-fest": "^4.8.3"
+			},
+			"peerDependencies": {
+				"vue": "^3.4.26"
+			}
+		},
+		"node_modules/vee-validate/node_modules/@vue/devtools-api": {
+			"version": "7.7.9",
+			"resolved": "https://registry.npmjs.org/@vue/devtools-api/-/devtools-api-7.7.9.tgz",
+			"integrity": "sha512-kIE8wvwlcZ6TJTbNeU2HQNtaxLx3a84aotTITUuL/4bzfPxzajGBOoqjMhwZJ8L9qFYDU/lAYMEEm11dnZOD6g==",
+			"license": "MIT",
+			"dependencies": {
+				"@vue/devtools-kit": "^7.7.9"
+			}
+		},
+		"node_modules/vee-validate/node_modules/@vue/devtools-kit": {
+			"version": "7.7.9",
+			"resolved": "https://registry.npmjs.org/@vue/devtools-kit/-/devtools-kit-7.7.9.tgz",
+			"integrity": "sha512-PyQ6odHSgiDVd4hnTP+aDk2X4gl2HmLDfiyEnn3/oV+ckFDuswRs4IbBT7vacMuGdwY/XemxBoh302ctbsptuA==",
+			"license": "MIT",
+			"dependencies": {
+				"@vue/devtools-shared": "^7.7.9",
+				"birpc": "^2.3.0",
+				"hookable": "^5.5.3",
+				"mitt": "^3.0.1",
+				"perfect-debounce": "^1.0.0",
+				"speakingurl": "^14.0.1",
+				"superjson": "^2.2.2"
+			}
+		},
+		"node_modules/vee-validate/node_modules/@vue/devtools-shared": {
+			"version": "7.7.9",
+			"resolved": "https://registry.npmjs.org/@vue/devtools-shared/-/devtools-shared-7.7.9.tgz",
+			"integrity": "sha512-iWAb0v2WYf0QWmxCGy0seZNDPdO3Sp5+u78ORnyeonS6MT4PC7VPrryX2BpMJrwlDeaZ6BD4vP4XKjK0SZqaeA==",
+			"license": "MIT",
+			"dependencies": {
+				"rfdc": "^1.4.1"
+			}
+		},
+		"node_modules/vee-validate/node_modules/birpc": {
+			"version": "2.9.0",
+			"resolved": "https://registry.npmjs.org/birpc/-/birpc-2.9.0.tgz",
+			"integrity": "sha512-KrayHS5pBi69Xi9JmvoqrIgYGDkD6mcSe/i6YKi3w5kekCLzrX4+nawcXqrj2tIp50Kw/mT/s3p+GVK0A0sKxw==",
+			"license": "MIT",
+			"funding": {
+				"url": "https://github.com/sponsors/antfu"
+			}
+		},
+		"node_modules/vee-validate/node_modules/hookable": {
+			"version": "5.5.3",
+			"resolved": "https://registry.npmjs.org/hookable/-/hookable-5.5.3.tgz",
+			"integrity": "sha512-Yc+BQe8SvoXH1643Qez1zqLRmbA5rCL+sSmk6TVos0LWVfNIB7PGncdlId77WzLGSIB5KaWgTaNTs2lNVEI6VQ==",
+			"license": "MIT"
+		},
+		"node_modules/vee-validate/node_modules/perfect-debounce": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/perfect-debounce/-/perfect-debounce-1.0.0.tgz",
+			"integrity": "sha512-xCy9V055GLEqoFaHoC1SoLIaLmWctgCUaBaWxDZ7/Zx4CTyX7cJQLJOok/orfjZAh9kEYpjJa4d0KcJmCbctZA==",
+			"license": "MIT"
+		},
+		"node_modules/vee-validate/node_modules/type-fest": {
+			"version": "4.41.0",
+			"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.41.0.tgz",
+			"integrity": "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==",
+			"license": "(MIT OR CC0-1.0)",
+			"engines": {
+				"node": ">=16"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
 		"node_modules/vite": {
 			"version": "7.3.3",
 			"resolved": "https://registry.npmjs.org/vite/-/vite-7.3.3.tgz",
@@ -15988,21 +16153,21 @@
 				"ufo": "^1.6.1"
 			}
 		},
-		"node_modules/vue-chartjs": {
-			"version": "5.3.3",
-			"resolved": "https://registry.npmjs.org/vue-chartjs/-/vue-chartjs-5.3.3.tgz",
-			"integrity": "sha512-jqxtL8KZ6YJ5NTv6XzrzLS7osyegOi28UGNZW0h9OkDL7Sh1396ht4Dorh04aKrl2LiSalQ84WtqiG0RIJb0tA==",
-			"license": "MIT",
-			"peerDependencies": {
-				"chart.js": "^4.1.1",
-				"vue": "^3.0.0-0 || ^2.7.0"
-			}
-		},
 		"node_modules/vue-devtools-stub": {
 			"version": "0.1.0",
 			"resolved": "https://registry.npmjs.org/vue-devtools-stub/-/vue-devtools-stub-0.1.0.tgz",
 			"integrity": "sha512-RutnB7X8c5hjq39NceArgXg28WZtZpGc3+J16ljMiYnFhKvd8hITxSWQSQ5bvldxMDU6gG5mkxl1MTQLXckVSQ==",
 			"license": "MIT"
+		},
+		"node_modules/vue-echarts": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/vue-echarts/-/vue-echarts-8.0.1.tgz",
+			"integrity": "sha512-23rJTFLu1OUEGRWjJGmdGt8fP+8+ja1gVgzMYPIPaHWpXegcO1viIAaeu2H4QHESlVeHzUAHIxKXGrwjsyXAaA==",
+			"license": "MIT",
+			"peerDependencies": {
+				"echarts": "^6.0.0",
+				"vue": "^3.3.0"
+			}
 		},
 		"node_modules/vue-eslint-parser": {
 			"version": "10.4.0",
@@ -17051,6 +17216,30 @@
 			"engines": {
 				"node": ">= 14"
 			}
+		},
+		"node_modules/zod": {
+			"version": "3.25.76",
+			"resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+			"integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+			"license": "MIT",
+			"funding": {
+				"url": "https://github.com/sponsors/colinhacks"
+			}
+		},
+		"node_modules/zrender": {
+			"version": "6.1.0",
+			"resolved": "https://registry.npmjs.org/zrender/-/zrender-6.1.0.tgz",
+			"integrity": "sha512-oEGMDB6pOP2S6OwRR4PdVv610zrjnA3Bh+JnSG12fYJlBKjtNAoEb5fSUoCOOINlH96I2fU38/A2UpRKs67xYQ==",
+			"license": "BSD-3-Clause",
+			"dependencies": {
+				"tslib": "2.3.0"
+			}
+		},
+		"node_modules/zrender/node_modules/tslib": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.0.tgz",
+			"integrity": "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg==",
+			"license": "0BSD"
 		}
 	}
 }

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
 		"@lucide/vue": "^1.16.0",
 		"@nuxtjs/i18n": "^10.4.0",
 		"@tailwindcss/vite": "^4.3.0",
-		"@vee-validate/zod": "^4.15.1",
+		"@tanstack/vue-form": "^1.33.0",
 		"@vueuse/nuxt": "^14.3.0",
 		"class-variance-authority": "^0.7.1",
 		"clsx": "^2.1.1",
@@ -32,7 +32,6 @@
 		"reka-ui": "^2.9.8",
 		"tailwind-merge": "^3.6.0",
 		"tailwindcss": "^4.3.0",
-		"vee-validate": "^4.15.1",
 		"vue-echarts": "^8.0.1",
 		"zod": "^3.25.76"
 	}

--- a/package.json
+++ b/package.json
@@ -24,13 +24,16 @@
 		"@lucide/vue": "^1.16.0",
 		"@nuxtjs/i18n": "^10.4.0",
 		"@tailwindcss/vite": "^4.3.0",
+		"@vee-validate/zod": "^4.15.1",
 		"@vueuse/nuxt": "^14.3.0",
-		"chart.js": "^4.5.1",
 		"class-variance-authority": "^0.7.1",
 		"clsx": "^2.1.1",
+		"echarts": "^6.1.0",
 		"reka-ui": "^2.9.8",
 		"tailwind-merge": "^3.6.0",
 		"tailwindcss": "^4.3.0",
-		"vue-chartjs": "^5.3.2"
+		"vee-validate": "^4.15.1",
+		"vue-echarts": "^8.0.1",
+		"zod": "^3.25.76"
 	}
 }

--- a/server/api/predict.post.ts
+++ b/server/api/predict.post.ts
@@ -1,9 +1,7 @@
-/// <reference types="@cloudflare/workers-types" />
-
 import {
-	apiToNormalizedRequest,
 	formatApiValidationError,
-	predictionApiSchema
+	predictionFormSchema,
+	toNormalizedRequest
 } from '#shared/predictionSchema';
 import { getPredictionDatabase, runPrediction } from '../utils/runPrediction';
 
@@ -19,7 +17,7 @@ export default defineEventHandler(async (event) => {
 		});
 	}
 
-	const parsed = predictionApiSchema.safeParse(requestBody);
+	const parsed = predictionFormSchema.safeParse(requestBody);
 	if (!parsed.success) {
 		throw createError({
 			statusCode: 400,
@@ -29,7 +27,7 @@ export default defineEventHandler(async (event) => {
 
 	try {
 		const db = getPredictionDatabase(event);
-		return await runPrediction(db, apiToNormalizedRequest(parsed.data));
+		return await runPrediction(db, toNormalizedRequest(parsed.data));
 	} catch (error: unknown) {
 		if (error instanceof Error && 'statusCode' in error) {
 			throw error;

--- a/server/utils/runPrediction.ts
+++ b/server/utils/runPrediction.ts
@@ -3,9 +3,6 @@
 import type { NormalizedPredictionRequest } from '#shared/predictionSchema';
 import { getPredictionWindow } from '~/utils/prediction';
 
-const { monthStart: DEFAULT_PREDICTION_MONTH_START, monthEnd: DEFAULT_PREDICTION_MONTH_END } =
-	getPredictionWindow();
-
 type PriceQueryRow = {
 	intercept_map: number;
 	month_map: number;
@@ -36,6 +33,7 @@ export async function runPrediction(
 	request: NormalizedPredictionRequest
 ): Promise<{ predictions: Array<{ month: string; predictedPrice: number }> }> {
 	const { mlModel, town, flatModel, storeyRange, floorAreaSqm, leaseCommenceYear } = request;
+	const { monthStart, monthEnd } = getPredictionWindow();
 
 	const { results } = await db
 		.prepare(
@@ -64,8 +62,8 @@ export async function runPrediction(
 			mlModel,
 			town,
 			flatModel,
-			DEFAULT_PREDICTION_MONTH_START,
-			DEFAULT_PREDICTION_MONTH_END,
+			monthStart,
+			monthEnd,
 			storeyRange
 		)
 		.all<PriceQueryRow>();

--- a/server/utils/runPrediction.ts
+++ b/server/utils/runPrediction.ts
@@ -1,0 +1,121 @@
+/// <reference types="@cloudflare/workers-types" />
+
+import type { NormalizedPredictionRequest } from '#shared/predictionSchema';
+import { getPredictionWindow } from '~/utils/prediction';
+
+const { monthStart: DEFAULT_PREDICTION_MONTH_START, monthEnd: DEFAULT_PREDICTION_MONTH_END } =
+	getPredictionWindow();
+
+type PriceQueryRow = {
+	intercept_map: number;
+	month_map: number;
+	storey_range_map: number;
+	floor_area_sqm_map: number;
+	lease_commence_date_map: number;
+	month_name: string;
+	month_multiplier: number;
+	town_map: number;
+	flat_model_map: number;
+	storey_range_multiplier: number;
+};
+
+function readNumericField(value: unknown, fieldName: string): number {
+	const numericValue = Number(value);
+	if (!Number.isFinite(numericValue)) {
+		throw new Error(`Database field ${fieldName} is not a finite number`);
+	}
+	return numericValue;
+}
+
+function roundToTwo(value: number): number {
+	return Math.round((value + Number.EPSILON) * 100) / 100;
+}
+
+export async function runPrediction(
+	db: D1Database,
+	request: NormalizedPredictionRequest
+): Promise<{ predictions: Array<{ month: string; predictedPrice: number }> }> {
+	const { mlModel, town, flatModel, storeyRange, floorAreaSqm, leaseCommenceYear } = request;
+
+	const { results } = await db
+		.prepare(
+			`SELECT
+				ml_models.intercept_map,
+				ml_models.month_map,
+				ml_models.storey_range_map,
+				ml_models.floor_area_sqm_map,
+				ml_models.lease_commence_date_map,
+				months_ordinal.name AS month_name,
+				months_ordinal.value AS month_multiplier,
+				towns_onehot.value AS town_map,
+				flat_models_onehot.value AS flat_model_map,
+				storey_ranges_ordinal.value AS storey_range_multiplier
+			FROM ml_models
+			JOIN towns_onehot ON ml_models.name = towns_onehot.ml_model
+			JOIN flat_models_onehot ON ml_models.name = flat_models_onehot.ml_model
+			JOIN storey_ranges_ordinal ON storey_ranges_ordinal.name = ?6
+			JOIN months_ordinal ON months_ordinal.name BETWEEN ?4 AND ?5
+			WHERE ml_models.name = ?1
+				AND towns_onehot.name = ?2
+				AND flat_models_onehot.name = ?3
+			ORDER BY months_ordinal.value ASC;`
+		)
+		.bind(
+			mlModel,
+			town,
+			flatModel,
+			DEFAULT_PREDICTION_MONTH_START,
+			DEFAULT_PREDICTION_MONTH_END,
+			storeyRange
+		)
+		.all<PriceQueryRow>();
+
+	const [first] = results;
+	if (!first) {
+		throw createError({
+			statusCode: 404,
+			statusMessage: 'No prediction data found for the given parameters.'
+		});
+	}
+
+	const baseValue =
+		readNumericField(first.intercept_map, 'intercept_map') +
+		readNumericField(first.town_map, 'town_map') +
+		readNumericField(first.storey_range_multiplier, 'storey_range_multiplier') *
+			readNumericField(first.storey_range_map, 'storey_range_map') +
+		floorAreaSqm * readNumericField(first.floor_area_sqm_map, 'floor_area_sqm_map') +
+		readNumericField(first.flat_model_map, 'flat_model_map') +
+		leaseCommenceYear * readNumericField(first.lease_commence_date_map, 'lease_commence_date_map');
+	const monthCoefficient = readNumericField(first.month_map, 'month_map');
+
+	const predictions = results.map((row) => {
+		const predictedRaw =
+			baseValue +
+			readNumericField(row.month_multiplier, 'month_multiplier') * monthCoefficient;
+
+		if (!Number.isFinite(predictedRaw)) {
+			throw new Error(
+				`Prediction calculation produced non-finite value for month ${row.month_name}`
+			);
+		}
+
+		return {
+			month: row.month_name,
+			predictedPrice: roundToTwo(Math.max(0, predictedRaw))
+		};
+	});
+
+	return { predictions };
+}
+
+export function getPredictionDatabase(event: import('h3').H3Event): D1Database {
+	const db = event.context.cloudflare?.env?.DB as D1Database | undefined;
+	if (!db) {
+		throw createError({
+			statusCode: 500,
+			statusMessage: 'Prediction service unavailable.'
+		});
+	}
+
+	return db;
+}

--- a/shared/predictionSchema.ts
+++ b/shared/predictionSchema.ts
@@ -1,0 +1,133 @@
+import { z } from 'zod';
+
+import {
+	FLAT_MODELS,
+	ML_MODELS,
+	STOREY_RANGES,
+	TOWNS,
+	type FlatModel,
+	type MLModel,
+	type StoreyRange,
+	type Town
+} from '~/utils/lists';
+import { MAX_LEASE_COMMENCE_YEAR } from '~/utils/prediction';
+
+const MIN_FLOOR_AREA_SQM = 20;
+const MAX_FLOOR_AREA_SQM = 300;
+const MIN_LEASE_COMMENCE_YEAR = 1960;
+
+function enumSchema<const T extends readonly string[]>(values: T) {
+	return z.enum(values as unknown as [T[number], ...T[number][]]);
+}
+
+export const predictionFormSchema = z.object({
+	ml_model: enumSchema<typeof ML_MODELS>(ML_MODELS),
+	town: enumSchema<typeof TOWNS>(TOWNS),
+	storey_range: enumSchema<typeof STOREY_RANGES>(STOREY_RANGES),
+	flat_model: enumSchema<typeof FLAT_MODELS>(FLAT_MODELS),
+	floor_area_sqm: z
+		.number({ invalid_type_error: 'invalid_floor_area' })
+		.finite('invalid_floor_area')
+		.int('invalid_floor_area')
+		.min(MIN_FLOOR_AREA_SQM, 'floor_area_out_of_range')
+		.max(MAX_FLOOR_AREA_SQM, 'floor_area_out_of_range'),
+	lease_commence_date: z
+		.number({ invalid_type_error: 'invalid_lease_commence_date' })
+		.finite('invalid_lease_commence_date')
+		.int('invalid_lease_commence_date')
+		.min(MIN_LEASE_COMMENCE_YEAR, 'lease_commence_date_out_of_range')
+		.max(MAX_LEASE_COMMENCE_YEAR, 'lease_commence_date_out_of_range')
+});
+
+export type PredictionFormInput = z.infer<typeof predictionFormSchema>;
+
+export const predictionApiSchema = z.object({
+	mlModel: enumSchema<typeof ML_MODELS>(ML_MODELS),
+	town: enumSchema<typeof TOWNS>(TOWNS),
+	storeyRange: enumSchema<typeof STOREY_RANGES>(STOREY_RANGES),
+	flatModel: enumSchema<typeof FLAT_MODELS>(FLAT_MODELS),
+	floorAreaSqm: z
+		.number({ invalid_type_error: 'invalid_floor_area' })
+		.finite('invalid_floor_area')
+		.min(MIN_FLOOR_AREA_SQM, 'floor_area_out_of_range')
+		.max(MAX_FLOOR_AREA_SQM, 'floor_area_out_of_range'),
+	leaseCommenceYear: z
+		.number({ invalid_type_error: 'invalid_lease_commence_date' })
+		.finite('invalid_lease_commence_date')
+		.int('invalid_lease_commence_date')
+		.min(MIN_LEASE_COMMENCE_YEAR, 'lease_commence_date_out_of_range')
+		.max(MAX_LEASE_COMMENCE_YEAR, 'lease_commence_date_out_of_range')
+});
+
+export type PredictionApiInput = z.infer<typeof predictionApiSchema>;
+
+export type NormalizedPredictionRequest = {
+	mlModel: MLModel;
+	town: Town;
+	storeyRange: StoreyRange;
+	flatModel: FlatModel;
+	floorAreaSqm: number;
+	leaseCommenceYear: number;
+};
+
+export function toNormalizedRequest(input: PredictionFormInput): NormalizedPredictionRequest {
+	return {
+		mlModel: input.ml_model,
+		town: input.town,
+		storeyRange: input.storey_range,
+		flatModel: input.flat_model,
+		floorAreaSqm: Math.max(
+			MIN_FLOOR_AREA_SQM,
+			Math.min(MAX_FLOOR_AREA_SQM, Math.round(input.floor_area_sqm))
+		),
+		leaseCommenceYear: input.lease_commence_date
+	};
+}
+
+export function apiToNormalizedRequest(input: PredictionApiInput): NormalizedPredictionRequest {
+	return {
+		mlModel: input.mlModel,
+		town: input.town,
+		storeyRange: input.storeyRange,
+		flatModel: input.flatModel,
+		floorAreaSqm: Math.max(
+			MIN_FLOOR_AREA_SQM,
+			Math.min(MAX_FLOOR_AREA_SQM, Math.round(input.floorAreaSqm))
+		),
+		leaseCommenceYear: input.leaseCommenceYear
+	};
+}
+
+const API_FIELD_ERRORS: Record<string, string> = {
+	invalid_type: 'Invalid request body.',
+	invalid_floor_area: 'Invalid floor area.',
+	floor_area_out_of_range: 'Invalid floor area.',
+	invalid_lease_commence_date: `Lease commence year must be between ${MIN_LEASE_COMMENCE_YEAR} and ${MAX_LEASE_COMMENCE_YEAR}.`,
+	lease_commence_date_out_of_range: `Lease commence year must be between ${MIN_LEASE_COMMENCE_YEAR} and ${MAX_LEASE_COMMENCE_YEAR}.`
+};
+
+const API_ENUM_FIELD_ERRORS: Partial<Record<keyof PredictionApiInput, string>> = {
+	mlModel: 'Invalid ML model.',
+	town: 'Invalid town.',
+	storeyRange: 'Invalid storey range.',
+	flatModel: 'Invalid flat model.'
+};
+
+export function formatApiValidationError(error: z.ZodError): string {
+	const [issue] = error.issues;
+	if (!issue) {
+		return 'Invalid request body.';
+	}
+
+	const messageKey = typeof issue.message === 'string' ? issue.message : 'invalid_type';
+	if (messageKey in API_FIELD_ERRORS) {
+		return API_FIELD_ERRORS[messageKey]!;
+	}
+
+	const field = issue.path[0];
+	if (typeof field === 'string' && field in API_ENUM_FIELD_ERRORS) {
+		return API_ENUM_FIELD_ERRORS[field as keyof PredictionApiInput]!;
+	}
+
+	return 'Invalid request body.';
+}

--- a/shared/predictionSchema.ts
+++ b/shared/predictionSchema.ts
@@ -28,7 +28,6 @@ export const predictionFormSchema = z.object({
 	floor_area_sqm: z
 		.number({ invalid_type_error: 'invalid_floor_area' })
 		.finite('invalid_floor_area')
-		.int('invalid_floor_area')
 		.min(MIN_FLOOR_AREA_SQM, 'floor_area_out_of_range')
 		.max(MAX_FLOOR_AREA_SQM, 'floor_area_out_of_range'),
 	lease_commence_date: z
@@ -106,11 +105,14 @@ const API_FIELD_ERRORS: Record<string, string> = {
 	lease_commence_date_out_of_range: `Lease commence year must be between ${MIN_LEASE_COMMENCE_YEAR} and ${MAX_LEASE_COMMENCE_YEAR}.`
 };
 
-const API_ENUM_FIELD_ERRORS: Partial<Record<keyof PredictionApiInput, string>> = {
+const API_ENUM_FIELD_ERRORS: Record<string, string> = {
 	mlModel: 'Invalid ML model.',
+	ml_model: 'Invalid ML model.',
 	town: 'Invalid town.',
 	storeyRange: 'Invalid storey range.',
-	flatModel: 'Invalid flat model.'
+	storey_range: 'Invalid storey range.',
+	flatModel: 'Invalid flat model.',
+	flat_model: 'Invalid flat model.'
 };
 
 export function formatApiValidationError(error: z.ZodError): string {
@@ -126,7 +128,7 @@ export function formatApiValidationError(error: z.ZodError): string {
 
 	const field = issue.path[0];
 	if (typeof field === 'string' && field in API_ENUM_FIELD_ERRORS) {
-		return API_ENUM_FIELD_ERRORS[field as keyof PredictionApiInput]!;
+		return API_ENUM_FIELD_ERRORS[field]!;
 	}
 
 	return 'Invalid request body.';

--- a/types/echarts-theme.d.ts
+++ b/types/echarts-theme.d.ts
@@ -1,0 +1,1 @@
+declare module 'echarts/theme/dark.js';


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Refactors the form → fetch → display flow to idiomatic Nuxt 4 + Vue Composition API patterns while preserving the existing data contract and features.

## Changes

- **Shared validation**: `shared/predictionSchema.ts` — single Zod schema (enums from `lists.ts`, bounds from `prediction.ts`) used on client (TanStack Form) and server (Nitro).
- **Form**: `@tanstack/vue-form` with `validators: { onChange: predictionFormSchema }`; fields via `<form.Field>` slots; bilingual errors from `field.state.meta.errors`.
- **API**: `POST /api/predict` (snake_case body) re-validates and runs D1 prediction; client only calls this route. `POST /api/prices` (camelCase) kept for compatibility via shared `server/utils/runPrediction.ts`.
- **State**: `useState` + `useLocalStorage` for SSR-safe, persisted form values.
- **Chart**: `vue-echarts` + tree-shaken `echarts/core` (SVG renderer); explicit `echarts/theme/dark.js` import for dark mode.
- **Formatting**: locale-aware `Intl.NumberFormat` (`en-SG` / `zh-Hans-SG`).

## Review feedback addressed

- **Enum API errors**: `formatApiValidationError` maps camelCase and snake_case field keys for `/api/predict` and `/api/prices`.
- **ECharts dark theme**: `import 'echarts/theme/dark.js'` + `types/echarts-theme.d.ts`.
- **Decimal floor area**: Zod schemas accept decimals; `toNormalizedRequest` rounds with `Math.round`. HTML input uses `step="any"` and `inputmode="decimal"` so browser validation matches Zod.
- **Floor area error display**: single `fieldError()` evaluation in the floor-area field template.

## Removed

- `vee-validate`, `@vee-validate/zod`, `chart.js`, `vue-chartjs`

## Verification

- `npm install`
- `npm run typecheck`
- `npm run lint`
- `npm run build`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5b98e529-3e23-461b-be76-e1c393b8627e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5b98e529-3e23-461b-be76-e1c393b8627e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

